### PR TITLE
[FEAT] 마이페이지 프로필 API 연결 

### DIFF
--- a/GAM/GAM.xcodeproj/project.pbxproj
+++ b/GAM/GAM.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		845DB2AC2B5034DD007E7ED9 /* WriteProjectViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845DB2AB2B5034DD007E7ED9 /* WriteProjectViewType.swift */; };
 		845DB2AE2B504914007E7ED9 /* UpdatePortfolioRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845DB2AD2B504914007E7ED9 /* UpdatePortfolioRequestDTO.swift */; };
+		848403C92B514A2C009249E3 /* ProfileResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848403C82B514A2C009249E3 /* ProfileResponseDTO.swift */; };
 		84903EE62B4C350600BD1F1B /* CreatePortfolioRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84903EE52B4C350600BD1F1B /* CreatePortfolioRequestDTO.swift */; };
 		84A7297F2B4EB5400060AF91 /* UpdateLinkRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A7297E2B4EB5400060AF91 /* UpdateLinkRequestDTO.swift */; };
 		84C03A092B4D0D7A0058EC79 /* ImageUrlRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C03A082B4D0D7A0058EC79 /* ImageUrlRequestDTO.swift */; };
@@ -183,6 +184,7 @@
 /* Begin PBXFileReference section */
 		845DB2AB2B5034DD007E7ED9 /* WriteProjectViewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteProjectViewType.swift; sourceTree = "<group>"; };
 		845DB2AD2B504914007E7ED9 /* UpdatePortfolioRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePortfolioRequestDTO.swift; sourceTree = "<group>"; };
+		848403C82B514A2C009249E3 /* ProfileResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileResponseDTO.swift; sourceTree = "<group>"; };
 		84903EE52B4C350600BD1F1B /* CreatePortfolioRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePortfolioRequestDTO.swift; sourceTree = "<group>"; };
 		84A7297E2B4EB5400060AF91 /* UpdateLinkRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateLinkRequestDTO.swift; sourceTree = "<group>"; };
 		84C03A082B4D0D7A0058EC79 /* ImageUrlRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUrlRequestDTO.swift; sourceTree = "<group>"; };
@@ -383,6 +385,7 @@
 				84E6F9932B4BF9CA009C4C15 /* PortfolioResponseDTO.swift */,
 				84E6F99C2B4C24EE009C4C15 /* DefaultPortfolioResponseDTO.swift */,
 				84C03A0A2B4D16F80058EC79 /* ImageUrlResponseDTO.swift */,
+				848403C82B514A2C009249E3 /* ProfileResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1151,6 +1154,7 @@
 				FFA706EA2A4F39E4003DF6A0 /* MagazineViewController.swift in Sources */,
 				FFD9DAFD2A7A58CA0085B965 /* MyProfileViewController.swift in Sources */,
 				FFA7070C2A584FC3003DF6A0 /* Tag.swift in Sources */,
+				848403C92B514A2C009249E3 /* ProfileResponseDTO.swift in Sources */,
 				FFC733872A71147A008B5054 /* UserProfileViewController.swift in Sources */,
 				FFC7337E2A6FB90A008B5054 /* SelectedFilterTagView.swift in Sources */,
 				FFA94CCC2A4EFAE5009B034F /* HomeViewController.swift in Sources */,

--- a/GAM/GAM.xcodeproj/project.pbxproj
+++ b/GAM/GAM.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		848403C92B514A2C009249E3 /* ProfileResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848403C82B514A2C009249E3 /* ProfileResponseDTO.swift */; };
 		84903EE62B4C350600BD1F1B /* CreatePortfolioRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84903EE52B4C350600BD1F1B /* CreatePortfolioRequestDTO.swift */; };
 		84A7297F2B4EB5400060AF91 /* UpdateLinkRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A7297E2B4EB5400060AF91 /* UpdateLinkRequestDTO.swift */; };
+		84BBCBF62B52CB2C0010F2AE /* UpdateProfileRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BBCBF52B52CB2C0010F2AE /* UpdateProfileRequestDTO.swift */; };
+		84BBCBF82B52CC900010F2AE /* UpdateProfileResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BBCBF72B52CC900010F2AE /* UpdateProfileResponseDTO.swift */; };
 		84C03A092B4D0D7A0058EC79 /* ImageUrlRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C03A082B4D0D7A0058EC79 /* ImageUrlRequestDTO.swift */; };
 		84C03A0B2B4D16F80058EC79 /* ImageUrlResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C03A0A2B4D16F80058EC79 /* ImageUrlResponseDTO.swift */; };
 		84C03A0D2B4E40500058EC79 /* UploadImageRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C03A0C2B4E40500058EC79 /* UploadImageRequestDTO.swift */; };
@@ -187,6 +189,8 @@
 		848403C82B514A2C009249E3 /* ProfileResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileResponseDTO.swift; sourceTree = "<group>"; };
 		84903EE52B4C350600BD1F1B /* CreatePortfolioRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePortfolioRequestDTO.swift; sourceTree = "<group>"; };
 		84A7297E2B4EB5400060AF91 /* UpdateLinkRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateLinkRequestDTO.swift; sourceTree = "<group>"; };
+		84BBCBF52B52CB2C0010F2AE /* UpdateProfileRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProfileRequestDTO.swift; sourceTree = "<group>"; };
+		84BBCBF72B52CC900010F2AE /* UpdateProfileResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProfileResponseDTO.swift; sourceTree = "<group>"; };
 		84C03A082B4D0D7A0058EC79 /* ImageUrlRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUrlRequestDTO.swift; sourceTree = "<group>"; };
 		84C03A0A2B4D16F80058EC79 /* ImageUrlResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUrlResponseDTO.swift; sourceTree = "<group>"; };
 		84C03A0C2B4E40500058EC79 /* UploadImageRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadImageRequestDTO.swift; sourceTree = "<group>"; };
@@ -386,6 +390,7 @@
 				84E6F99C2B4C24EE009C4C15 /* DefaultPortfolioResponseDTO.swift */,
 				84C03A0A2B4D16F80058EC79 /* ImageUrlResponseDTO.swift */,
 				848403C82B514A2C009249E3 /* ProfileResponseDTO.swift */,
+				84BBCBF72B52CC900010F2AE /* UpdateProfileResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -399,6 +404,7 @@
 				84C03A0C2B4E40500058EC79 /* UploadImageRequestDTO.swift */,
 				84A7297E2B4EB5400060AF91 /* UpdateLinkRequestDTO.swift */,
 				845DB2AD2B504914007E7ED9 /* UpdatePortfolioRequestDTO.swift */,
+				84BBCBF52B52CB2C0010F2AE /* UpdateProfileRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1229,9 +1235,11 @@
 				FF0FA60F2A6D862300482841 /* BrowseScrapCollectionViewCell.swift in Sources */,
 				FFCDF86C2A5AFB4300C731A3 /* RecentMagazineTableHeaderView.swift in Sources */,
 				FFA94CDC2A4F0966009B034F /* BaseNavigationController.swift in Sources */,
+				84BBCBF62B52CB2C0010F2AE /* UpdateProfileRequestDTO.swift in Sources */,
 				FFA94D272A4F1E4A009B034F /* GamTabBarController.swift in Sources */,
 				FFC733892A716845008B5054 /* UserPortfolioEntity.swift in Sources */,
 				FF6CC0472A963FD500B24C94 /* UserService.swift in Sources */,
+				84BBCBF82B52CC900010F2AE /* UpdateProfileResponseDTO.swift in Sources */,
 				FFA94CF72A4F1AFD009B034F /* UserDefaults+.swift in Sources */,
 				84903EE62B4C350600BD1F1B /* CreatePortfolioRequestDTO.swift in Sources */,
 				FFD9DAF72A79668E0085B965 /* ToastMessageType.swift in Sources */,

--- a/GAM/GAM/Network/DTO/Mypage/Request/UpdateProfileRequestDTO.swift
+++ b/GAM/GAM/Network/DTO/Mypage/Request/UpdateProfileRequestDTO.swift
@@ -1,0 +1,22 @@
+//
+//  UpdateProfileRequestDTO.swift
+//  GAM
+//
+//  Created by Juhyeon Byun on 1/13/24.
+//
+
+import Foundation
+
+struct UpdateProfileRequestDTO: Encodable {
+    let userInfo: String
+    let userDetail: String
+    let email: String
+    let tags: [Int]
+    
+    init(userInfo: String, userDetail: String, email: String, tags: [Int]) {
+        self.userInfo = userInfo
+        self.userDetail = userDetail
+        self.email = email
+        self.tags = tags
+    }
+}

--- a/GAM/GAM/Network/DTO/Mypage/Response/PortfolioResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/Mypage/Response/PortfolioResponseDTO.swift
@@ -14,7 +14,7 @@ struct PortfolioResponseDTO: Decodable {
     let works: [Work]
 }
 
-struct Work: Codable {
+struct Work: Decodable {
     let workId: Int
     let workThumbNail, workTitle, workDetail: String
 }

--- a/GAM/GAM/Network/DTO/Mypage/Response/ProfileResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/Mypage/Response/ProfileResponseDTO.swift
@@ -1,0 +1,21 @@
+//
+//  ProfileResponseDTO.swift
+//  GAM
+//
+//  Created by Juhyeon Byun on 1/12/24.
+//
+
+import Foundation
+
+struct ProfileResponseDTO: Decodable {
+    let userId: Int
+    let userName, info, detail, email: String
+    let userTag: [Int]
+}
+
+
+extension ProfileResponseDTO {
+    func toUserProfileEntity() -> UserProfileEntity {
+        return UserProfileEntity(userID: userId, name: userName, isScrap: false, info: info, infoDetail: detail, tags: userTag, email: email)
+    }
+}

--- a/GAM/GAM/Network/DTO/Mypage/Response/UpdateProfileResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/Mypage/Response/UpdateProfileResponseDTO.swift
@@ -1,0 +1,21 @@
+//
+//  UpdateProfileResponseDTO.swift
+//  GAM
+//
+//  Created by Juhyeon Byun on 1/13/24.
+//
+
+import Foundation
+
+struct UpdateProfileResponseDTO: Decodable {
+    let userInfo: String
+    let userDetail: String
+    let email: String
+    let tags: [Int]
+}
+
+extension UpdateProfileResponseDTO {
+    func toUserProfileEntity() -> UserProfileEntity {
+        return UserProfileEntity(userID: 0, name: "", isScrap: false, info: userInfo, infoDetail: userDetail, tags: tags, email: email)
+    }
+}

--- a/GAM/GAM/Network/Routers/MypageRouter.swift
+++ b/GAM/GAM/Network/Routers/MypageRouter.swift
@@ -17,6 +17,7 @@ enum MypageRouter {
     case uploadImage(data: UploadImageRequestDTO)
     case updateLink(contactUrlType: ContactURLType, data: UpdateLinkRequestDTO)
     case updatePortfolio(data: UpdatePortfolioRequestDTO)
+    case getProfile
 }
 
 extension MypageRouter: TargetType {
@@ -46,12 +47,14 @@ extension MypageRouter: TargetType {
             return "/user/link/\(contactUrlType.rawValue)"
         case .updatePortfolio:
             return "/work/edit"
+        case .getProfile:
+            return "/user/my/profile"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getPortfolio, .getImageUrl:
+        case .getPortfolio, .getImageUrl, .getProfile:
             return .get
         case .setRepPortfolio, .updateLink, .updatePortfolio:
             return .patch
@@ -66,7 +69,7 @@ extension MypageRouter: TargetType {
     
     var task: Task {
         switch self {
-        case .getPortfolio:
+        case .getPortfolio, .getProfile:
             return .requestPlain
         case .setRepPortfolio(let data), .deletePortfolio(let data):
             return .requestJSONEncodable(data)
@@ -89,14 +92,14 @@ extension MypageRouter: TargetType {
     
     var headers: [String: String]? {
         switch self {
-        case .getPortfolio, .setRepPortfolio, .deletePortfolio, .createPortfolio, .getImageUrl, .updateLink, .updatePortfolio:
-            return [
-                "Content-Type": "application/json",
-                "Authorization": UserInfo.shared.accessToken
-            ]
         case .uploadImage:
             return [
                 "Content-Type": "image/jpeg"
+            ]
+        default:
+            return [
+                "Content-Type": "application/json",
+                "Authorization": UserInfo.shared.accessToken
             ]
         }
     }

--- a/GAM/GAM/Network/Routers/MypageRouter.swift
+++ b/GAM/GAM/Network/Routers/MypageRouter.swift
@@ -18,6 +18,7 @@ enum MypageRouter {
     case updateLink(contactUrlType: ContactURLType, data: UpdateLinkRequestDTO)
     case updatePortfolio(data: UpdatePortfolioRequestDTO)
     case getProfile
+    case updateProfile(data: UpdateProfileRequestDTO)
 }
 
 extension MypageRouter: TargetType {
@@ -49,6 +50,8 @@ extension MypageRouter: TargetType {
             return "/work/edit"
         case .getProfile:
             return "/user/my/profile"
+        case .updateProfile:
+            return "/user/introduce"
         }
     }
     
@@ -56,7 +59,7 @@ extension MypageRouter: TargetType {
         switch self {
         case .getPortfolio, .getImageUrl, .getProfile:
             return .get
-        case .setRepPortfolio, .updateLink, .updatePortfolio:
+        case .setRepPortfolio, .updateLink, .updatePortfolio, .updateProfile:
             return .patch
         case .deletePortfolio:
             return .delete
@@ -85,6 +88,8 @@ extension MypageRouter: TargetType {
         case .updateLink(_, let data):
             return .requestJSONEncodable(data)
         case .updatePortfolio(let data):
+            return .requestJSONEncodable(data)
+        case .updateProfile(let data):
             return .requestJSONEncodable(data)
         }
     }

--- a/GAM/GAM/Network/Services/MypageService.swift
+++ b/GAM/GAM/Network/Services/MypageService.swift
@@ -10,6 +10,14 @@ import Moya
 
 internal protocol MypageServiceProtocol {
     func getPortfolio(completion: @escaping (NetworkResult<Any>) -> (Void))
+    func setRepPortfolio(data: SetPortfolioRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void))
+    func deletePortfolio(data: SetPortfolioRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void))
+    func createPortfolio(data: CreatePortfolioRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void))
+    func getImageUrl(data: ImageUrlRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void))
+    func uploadImage(data: UploadImageRequestDTO, completion: @escaping () -> ())
+    func updateLink(contactUrlType: ContactURLType, data: UpdateLinkRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void))
+    func updatePortfolio(data: UpdatePortfolioRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void))
+    func getProfile(completion: @escaping (NetworkResult<Any>) -> (Void))
 }
 
 final class MypageService: BaseService {
@@ -133,6 +141,21 @@ extension MypageService: MypageServiceProtocol {
                 let statusCode = response.statusCode
                 let data = response.data
                 let networkResult = self.judgeStatus(by: statusCode, data, DefaultPortfolioResponseDTO.self)
+                completion(networkResult)
+            case .failure(let error):
+                debugPrint(error)
+            }
+        }
+    }
+    
+    // [GET] 프로필 조회
+    func getProfile(completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        self.provider.request(.getProfile) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, ProfileResponseDTO.self)
                 completion(networkResult)
             case .failure(let error):
                 debugPrint(error)

--- a/GAM/GAM/Network/Services/MypageService.swift
+++ b/GAM/GAM/Network/Services/MypageService.swift
@@ -162,4 +162,19 @@ extension MypageService: MypageServiceProtocol {
             }
         }
     }
+    
+    // [PATCH] 프로필 업데이트
+    func updateProfile(data: UpdateProfileRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        self.provider.request(.updateProfile(data: data)) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, UpdateProfileResponseDTO.self)
+                completion(networkResult)
+            case .failure(let error):
+                debugPrint(error)
+            }
+        }
+    }
 }

--- a/GAM/GAM/Sources/Components/View/ProfileInfoView.swift
+++ b/GAM/GAM/Sources/Components/View/ProfileInfoView.swift
@@ -10,6 +10,9 @@ import SnapKit
 
 final class ProfileInfoView: UIView {
     
+    // MARK: Properties
+    private let detailPlaceholder = "경험 위주 자기소개 부탁드립니다."
+    
     // MARK: UIComponents
     
     let infoTextField: UITextField = {
@@ -51,7 +54,14 @@ final class ProfileInfoView: UIView {
     
     func setData(info: String, detail: String) {
         self.infoTextField.text = info
-        self.detailTextView.text = detail
+        
+        if detail.isEmpty {
+            self.detailTextView.text = detailPlaceholder
+            self.detailTextView.textColor = .gamGray3
+        } else {
+            self.detailTextView.text = detail
+            self.detailTextView.textColor = .gamBlack
+        }
     }
     
     private func setUI(isEditable: Bool) {

--- a/GAM/GAM/Sources/Entities/UserProfileEntity.swift
+++ b/GAM/GAM/Sources/Entities/UserProfileEntity.swift
@@ -11,10 +11,10 @@ struct UserProfileEntity {
     let userID: Int
     let name: String
     let isScrap: Bool
-    let info: String
-    let infoDetail: String
-    let tags: [TagEntity]
-    let email: String
+    var info: String
+    var infoDetail: String
+    var tags: [TagEntity]
+    var email: String
     
     static func == (lhs: UserProfileEntity, rhs: UserProfileEntity) -> Bool {
         return lhs.userID == rhs.userID

--- a/GAM/GAM/Sources/Screens/My/EditProfileViewController.swift
+++ b/GAM/GAM/Sources/Screens/My/EditProfileViewController.swift
@@ -212,15 +212,23 @@ final class EditProfileViewController: BaseViewController {
             .distinctUntilChanged()
             .withUnretained(self)
             .subscribe(onNext: { (owner, changedText) in
-                self.profile.infoDetail = changedText
-                self.profileInfoView.detailTextView.text.removeLastSpace()
+                owner.profile.infoDetail = changedText
+                owner.profileInfoView.detailTextView.text.removeLastSpace()
+                
                 if changedText.count > 150 {
-                    self.profileInfoView.detailTextView.deleteBackward()
+                    owner.profileInfoView.detailTextView.deleteBackward()
+                } else if changedText == Text.detailPlaceholder {
+                    owner.profileInfoDetailCountLabel.text = "0/150"
                 } else {
-                    self.profileInfoDetailCountLabel.text = "\(changedText.count)/150"
+                    owner.profileInfoDetailCountLabel.text = "\(changedText.count)/150"
                 }
             })
-            .disposed(by: self.disposeBag)
+            .disposed(by: disposeBag)
+        
+        if profileInfoView.detailTextView.text.count == 0 {
+            self.profileInfoView.detailTextView.text =  Text.detailPlaceholder
+            self.profileInfoView.detailTextView.textColor = .gamGray3
+        }
     }
     
     private func setEmailTextField() {
@@ -253,7 +261,8 @@ final class EditProfileViewController: BaseViewController {
     private func setSaveButtonAction() {
         self.navigationView.saveButton.setAction { [weak self] in
             if let profile = self?.profile, let tags = self?.tagCollectionView.indexPathsForSelectedItems?.map({ $0.item + 1 }) {
-                self?.updateProfile(userInfo: profile.info, userDetail: profile.infoDetail, email: profile.email, tags: tags) { responseData in
+                let infoDetail = profile.infoDetail == Text.detailPlaceholder ? "" : profile.infoDetail
+                self?.updateProfile(userInfo: profile.info, userDetail: infoDetail, email: profile.email, tags: tags) { responseData in
                     self?.sendUpdateDelegate?.sendUpdate(data: responseData)
                     self?.navigationController?.popViewController(animated: true)
                 }
@@ -302,7 +311,6 @@ extension EditProfileViewController: UITextViewDelegate {
         textView.endEditing(true)
         if self.profileInfoView.detailTextView.text.isEmpty {
             self.profileInfoView.detailTextView.text =  Text.detailPlaceholder
-            self.profileInfoDetailCountLabel.text = "0/150"
             self.profileInfoView.detailTextView.textColor = .gamGray3
         }
     }

--- a/GAM/GAM/Sources/Screens/My/EditProfileViewController.swift
+++ b/GAM/GAM/Sources/Screens/My/EditProfileViewController.swift
@@ -21,7 +21,7 @@ final class EditProfileViewController: BaseViewController {
         static let profileInfo = "한 줄 소개를 입력해 주세요."
         static let tagInfo = "최소 1개 선택해 주세요."
         static let emailInfo = "올바른 이메일을 입력해 주세요."
-        static let detailPlaceholder = "자신에 대해 다채롭게 표현해 보세요!"
+        static let detailPlaceholder = "경험 위주 자기소개 부탁드립니다."
     }
     
     private enum Number {
@@ -188,24 +188,25 @@ final class EditProfileViewController: BaseViewController {
     }
     
     private func setProfileInfoView() {
-        self.profileInfoView.infoTextField.rx.observe(String.self, "text")
+        self.profileInfoView.infoTextField.rx.text
+            .orEmpty
             .distinctUntilChanged()
-            .observe(on: MainScheduler.asyncInstance)
-            .subscribe(onNext: { changedText in
-                guard let text = changedText else { return }
-                self.profile.info = text
-                self.profileInfoView.infoTextField.text?.removeLastSpace()
-                if text.count > 20 {
-                    self.profileInfoView.infoTextField.deleteBackward()
+            .withUnretained(self)
+            .subscribe(onNext: { (owner, changedText) in
+                owner.profile.info = changedText
+                owner.profileInfoView.infoTextField.text?.removeLastSpace()
+                if changedText.count > 20 {
+                    owner.profileInfoView.infoTextField.deleteBackward()
                 }
-                if text.count > 0 {
-                    self.profileInfoView.layer.borderWidth = 0
-                    self.profileInfoLabel.isHidden = true
+                if changedText.count > 0 {
+                    owner.profileInfoView.layer.borderWidth = 0
+                    owner.profileInfoLabel.isHidden = true
                 } else {
-                    self.profileInfoView.layer.borderWidth = 1
-                    self.profileInfoLabel.isHidden = false
+                    owner.profileInfoView.layer.borderWidth = 1
+                    owner.profileInfoLabel.isHidden = false
                 }
-        }).disposed(by: disposeBag)
+            })
+            .disposed(by: disposeBag)
         
         self.profileInfoView.detailTextView.rx.text
             .orEmpty

--- a/GAM/GAM/Sources/Screens/My/MyPortfolioViewController.swift
+++ b/GAM/GAM/Sources/Screens/My/MyPortfolioViewController.swift
@@ -73,11 +73,9 @@ final class MyPortfolioViewController: BaseViewController {
     
     private func fetchData() {
         self.getPortfolio { portfolio in
-            DispatchQueue.main.async {
-                self.portfolio = portfolio
-                self.portfolioTableView.reloadData()
-                self.setEmptyView()
-            }
+            self.portfolio = portfolio
+            self.portfolioTableView.reloadData()
+            self.setEmptyView()
         }
     }
     

--- a/GAM/GAM/Sources/Screens/My/MyPortfolioViewController.swift
+++ b/GAM/GAM/Sources/Screens/My/MyPortfolioViewController.swift
@@ -280,7 +280,7 @@ extension MyPortfolioViewController: SendUpdateDelegate {
         if let scrollToTop = data as? Bool, scrollToTop {
             if self.portfolioTableView.numberOfSections > 0 {
                 if self.portfolioTableView.numberOfRows(inSection: 0) > 0 {
-                    self.portfolioTableView.scrollToRow(at: IndexPath(row: 1, section: 0), at: .top, animated: true)
+                    self.portfolioTableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
                 }
             }
         }

--- a/GAM/GAM/Sources/Screens/My/MyProfileViewController.swift
+++ b/GAM/GAM/Sources/Screens/My/MyProfileViewController.swift
@@ -75,6 +75,7 @@ final class MyProfileViewController: BaseViewController {
         
         self.setLayout()
         self.setTagCollectionView()
+        self.setEditButtonAction()
     }
     
     // MARK: Methods
@@ -94,8 +95,24 @@ final class MyProfileViewController: BaseViewController {
         )
         self.tagCollectionView.reloadData()
         self.emailTextField.text = profile.email
+    }
+    
+    func setEditButtonAction() {
         self.editButton.setAction { [weak self] in
-            self?.superViewController?.navigationController?.pushViewController(EditProfileViewController(profile: profile), animated: true)
+            guard let profile = self?.profile else { return }
+            let editProfileViewController = EditProfileViewController(profile: profile)
+            editProfileViewController.sendUpdateDelegate = self
+            self?.superViewController?.navigationController?.pushViewController(editProfileViewController, animated: true)
+        }
+    }
+}
+
+// MARK: - SendUpdateDelegate
+
+extension MyProfileViewController: SendUpdateDelegate {
+    func sendUpdate(data: Any?) {
+        if let data = data as? UserProfileEntity {
+            self.setData(profile: UserProfileEntity(userID: profile.userID, name: profile.name, isScrap: profile.isScrap, info: data.info, infoDetail: data.infoDetail, tags: data.tags.map { $0.id }, email: data.email))
         }
     }
 }

--- a/GAM/GAM/Sources/Screens/My/MyViewController.swift
+++ b/GAM/GAM/Sources/Screens/My/MyViewController.swift
@@ -44,23 +44,6 @@ final class MyViewController: BaseViewController {
     
     fileprivate var contentViewControllers = [UIViewController]()
     
-    private var profile: UserProfileEntity = UserProfileEntity(
-        userID: 1,
-        name: "정정빈",
-        isScrap: true,
-        info: "사용자의 행복을 추구하는 디자이너",
-        infoDetail:
-"""
-안녕하세요! 저는 삶을 다채롭게 만드는 브랜드 디자이너
-입니다.
-
-
-
-창의성, 미적 감각을 바탕으로 제품과 경험을 통해사람들의 삶을 더 아름답고 풍요롭게 만들어 나가고 있습니다. 브랜드의 가치와 메시지를 시각적으로 전달하여 고객들의 인상을 주는 것을 목표로 하고 있습니다.
-""",
-        tags: [1, 4],
-        email: "must4rdev@gmail.com")
-    
     // MARK: View Life Cycle
     
     override func viewDidLoad() {
@@ -69,7 +52,7 @@ final class MyViewController: BaseViewController {
         self.setUpViews()
         self.setLayout()
         self.bindTabHeader()
-        self.fetchUserInfo()
+        self.updateUserProfile()
         self.setSettingButtonAction()
     }
     
@@ -104,26 +87,33 @@ final class MyViewController: BaseViewController {
             self?.navigationController?.pushViewController(BaseViewController(), animated: true)
         }
     }
+    
+    private func updateUserProfile() {
+        self.getUserProfile() { profile in
+            if let myProfileViewController = self.contentViewControllers[1] as? MyProfileViewController {
+                myProfileViewController.setData(profile: profile)
+            }
+            self.navigationView.setLeftTitle(profile.name)
+        }
+    }
 }
 
 // MARK: - Network
 
 extension MyViewController {
-    private func fetchUserInfo() {
-        self.getUserPortfolio()
-        self.getUserProfile()
-    }
-    
-    private func getUserPortfolio() {
-        
-    }
-    
-    private func getUserProfile() {
-        if let myProfileViewController = self.contentViewControllers[1] as? MyProfileViewController {
-            myProfileViewController.setData(profile: self.profile)
+    private func getUserProfile(completion: @escaping (UserProfileEntity) -> ()) {
+        self.startActivityIndicator()
+        MypageService.shared.getProfile { networkResult in
+            switch networkResult {
+            case .success(let responseData):
+                if let result = responseData as? ProfileResponseDTO {
+                    completion(result.toUserProfileEntity())
+                }
+            default:
+                self.showNetworkErrorAlert()
+            }
+            self.stopActivityIndicator()
         }
-        self.navigationView.setLeftTitle(self.profile.name)
-        self.navigationView.scrapButton.isSelected = self.profile.isScrap
     }
 }
 


### PR DESCRIPTION
## 작업한 내용
- 마이페이지 진입 시 profile get 요청
- 마이페이지 수정
    - 이 부분 원래 profile get 요청 다시 해도 되는데, response로도 바뀐 데이터 주길래 
    서버 요청 줄일겸 delegate에 데이터 넣어서 UI 업데이트 함~!
- 포트폴리오 생성 시 가장 상단으로 스크롤 지정

## 체크 포인트
- UserProfileEntity에 let -> var 수정한 부분있음
- 원래 코드 보니까 MyViewController에서 포트폴리오랑 프로필 둘 다 요청하는 걸로 되어있던데,
내가 포트폴리오 작업할 때는 MyPortfolioViewController에서 작업했어서 .. 괜찮은지 한 번 확인부탁!
- 소개뷰 보면 title이랑 detail 나눠져있는데, 코드가 동일함에도 불구하고 inset이 다르게 나옴 .. 뷰계층 봤는데 요상하게 되어있음 확인 부탁..!

## 📸 스크린샷
![프로필](https://github.com/Gam-develop/GAM-iOS/assets/58043306/1f495a7e-9deb-4334-a5ff-07a7f1db68a3)

## 관련 이슈
- Resolved: #42
