### PR TITLE
[FEAT] 둘러보기 탭 api 연결

### DIFF
--- a/GAM/GAM.xcodeproj/project.pbxproj
+++ b/GAM/GAM.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		FFC733952A78EA8A008B5054 /* ProfileInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC733942A78EA8A008B5054 /* ProfileInfoView.swift */; };
 		FFC733972A78FE90008B5054 /* UnselectableTagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC733962A78FE90008B5054 /* UnselectableTagCollectionViewCell.swift */; };
 		FFC733992A79002E008B5054 /* GamContactButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC733982A79002E008B5054 /* GamContactButton.swift */; };
+		FFC8324E2B566D4200825ADB /* SearchDesignerResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC8324D2B566D4200825ADB /* SearchDesignerResponseDTO.swift */; };
 		FFCDF84A2A5A4A2500C731A3 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = FFCDF8472A5A4A2500C731A3 /* Debug.xcconfig */; };
 		FFCDF84B2A5A4A2500C731A3 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = FFCDF8482A5A4A2500C731A3 /* Release.xcconfig */; };
 		FFCDF84C2A5A4A2500C731A3 /* Shared.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = FFCDF8492A5A4A2500C731A3 /* Shared.xcconfig */; };
@@ -177,11 +178,11 @@
 		FFD9DB0D2A7E43880085B965 /* EditProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD9DB0C2A7E43880085B965 /* EditProfileViewController.swift */; };
 		FFD9DB0F2A7F7F6F0085B965 /* WriteProjectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD9DB0E2A7F7F6F0085B965 /* WriteProjectViewController.swift */; };
 		FFD9DB112A80D16D0085B965 /* GamStarLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD9DB102A80D16D0085B965 /* GamStarLabel.swift */; };
+		FFEB5CA72B4E5F4F00953362 /* ScrapDesignerRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CA62B4E5F4F00953362 /* ScrapDesignerRequestDTO.swift */; };
+		FFEB5CA92B4E60BA00953362 /* ScrapDesignerResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CA82B4E60BA00953362 /* ScrapDesignerResponseDTO.swift */; };
 		FFEB5CAB2B4E844D00953362 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CAA2B4E844D00953362 /* SplashViewController.swift */; };
 		FFEB5CAD2B4F9B5000953362 /* RefreshTokenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CAC2B4F9B5000953362 /* RefreshTokenRequestDTO.swift */; };
 		FFEB5CAF2B4FA03200953362 /* RefreshTokenResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CAE2B4FA03200953362 /* RefreshTokenResponseDTO.swift */; };
-		FFEB5CA72B4E5F4F00953362 /* ScrapDesignerRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CA62B4E5F4F00953362 /* ScrapDesignerRequestDTO.swift */; };
-		FFEB5CA92B4E60BA00953362 /* ScrapDesignerResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CA82B4E60BA00953362 /* ScrapDesignerResponseDTO.swift */; };
 		FFEB5CB12B55AD4300953362 /* GetScrapDesignerResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CB02B55AD4300953362 /* GetScrapDesignerResponseDTO.swift */; };
 		FFEB5CB32B562F8300953362 /* GetBrowseDesignerResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CB22B562F8300953362 /* GetBrowseDesignerResponseDTO.swift */; };
 		FFF605C22A657CC400A1EEC6 /* BrowseDesignerEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF605C12A657CC400A1EEC6 /* BrowseDesignerEntity.swift */; };
@@ -313,6 +314,7 @@
 		FFC733942A78EA8A008B5054 /* ProfileInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInfoView.swift; sourceTree = "<group>"; };
 		FFC733962A78FE90008B5054 /* UnselectableTagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnselectableTagCollectionViewCell.swift; sourceTree = "<group>"; };
 		FFC733982A79002E008B5054 /* GamContactButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamContactButton.swift; sourceTree = "<group>"; };
+		FFC8324D2B566D4200825ADB /* SearchDesignerResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDesignerResponseDTO.swift; sourceTree = "<group>"; };
 		FFCDF8472A5A4A2500C731A3 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		FFCDF8482A5A4A2500C731A3 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		FFCDF8492A5A4A2500C731A3 /* Shared.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
@@ -354,11 +356,11 @@
 		FFD9DB0C2A7E43880085B965 /* EditProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewController.swift; sourceTree = "<group>"; };
 		FFD9DB0E2A7F7F6F0085B965 /* WriteProjectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteProjectViewController.swift; sourceTree = "<group>"; };
 		FFD9DB102A80D16D0085B965 /* GamStarLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamStarLabel.swift; sourceTree = "<group>"; };
+		FFEB5CA62B4E5F4F00953362 /* ScrapDesignerRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapDesignerRequestDTO.swift; sourceTree = "<group>"; };
+		FFEB5CA82B4E60BA00953362 /* ScrapDesignerResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapDesignerResponseDTO.swift; sourceTree = "<group>"; };
 		FFEB5CAA2B4E844D00953362 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		FFEB5CAC2B4F9B5000953362 /* RefreshTokenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshTokenRequestDTO.swift; sourceTree = "<group>"; };
 		FFEB5CAE2B4FA03200953362 /* RefreshTokenResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshTokenResponseDTO.swift; sourceTree = "<group>"; };
-		FFEB5CA62B4E5F4F00953362 /* ScrapDesignerRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapDesignerRequestDTO.swift; sourceTree = "<group>"; };
-		FFEB5CA82B4E60BA00953362 /* ScrapDesignerResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapDesignerResponseDTO.swift; sourceTree = "<group>"; };
 		FFEB5CB02B55AD4300953362 /* GetScrapDesignerResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetScrapDesignerResponseDTO.swift; sourceTree = "<group>"; };
 		FFEB5CB22B562F8300953362 /* GetBrowseDesignerResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBrowseDesignerResponseDTO.swift; sourceTree = "<group>"; };
 		FFF605C12A657CC400A1EEC6 /* BrowseDesignerEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseDesignerEntity.swift; sourceTree = "<group>"; };
@@ -533,6 +535,7 @@
 				FFEB5CA82B4E60BA00953362 /* ScrapDesignerResponseDTO.swift */,
 				FFEB5CB02B55AD4300953362 /* GetScrapDesignerResponseDTO.swift */,
 				FFEB5CB22B562F8300953362 /* GetBrowseDesignerResponseDTO.swift */,
+				FFC8324D2B566D4200825ADB /* SearchDesignerResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1254,6 +1257,7 @@
 				FFCDF86C2A5AFB4300C731A3 /* RecentMagazineTableHeaderView.swift in Sources */,
 				FFA94CDC2A4F0966009B034F /* BaseNavigationController.swift in Sources */,
 				84BBCBF62B52CB2C0010F2AE /* UpdateProfileRequestDTO.swift in Sources */,
+				FFC8324E2B566D4200825ADB /* SearchDesignerResponseDTO.swift in Sources */,
 				FFA94D272A4F1E4A009B034F /* GamTabBarController.swift in Sources */,
 				FFC733892A716845008B5054 /* UserPortfolioEntity.swift in Sources */,
 				FF6CC0472A963FD500B24C94 /* UserService.swift in Sources */,

--- a/GAM/GAM.xcodeproj/project.pbxproj
+++ b/GAM/GAM.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		FFD9DB112A80D16D0085B965 /* GamStarLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD9DB102A80D16D0085B965 /* GamStarLabel.swift */; };
 		FFEB5CA72B4E5F4F00953362 /* ScrapDesignerRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CA62B4E5F4F00953362 /* ScrapDesignerRequestDTO.swift */; };
 		FFEB5CA92B4E60BA00953362 /* ScrapDesignerResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CA82B4E60BA00953362 /* ScrapDesignerResponseDTO.swift */; };
+		FFEB5CB12B55AD4300953362 /* GetScrapDesignerResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CB02B55AD4300953362 /* GetScrapDesignerResponseDTO.swift */; };
 		FFF605C22A657CC400A1EEC6 /* BrowseDesignerEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF605C12A657CC400A1EEC6 /* BrowseDesignerEntity.swift */; };
 		FFF605C82A65809B00A1EEC6 /* BrowseScrapCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF605C72A65809B00A1EEC6 /* BrowseScrapCollectionHeaderView.swift */; };
 /* End PBXBuildFile section */
@@ -351,6 +352,7 @@
 		FFD9DB102A80D16D0085B965 /* GamStarLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamStarLabel.swift; sourceTree = "<group>"; };
 		FFEB5CA62B4E5F4F00953362 /* ScrapDesignerRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapDesignerRequestDTO.swift; sourceTree = "<group>"; };
 		FFEB5CA82B4E60BA00953362 /* ScrapDesignerResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapDesignerResponseDTO.swift; sourceTree = "<group>"; };
+		FFEB5CB02B55AD4300953362 /* GetScrapDesignerResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetScrapDesignerResponseDTO.swift; sourceTree = "<group>"; };
 		FFF605C12A657CC400A1EEC6 /* BrowseDesignerEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseDesignerEntity.swift; sourceTree = "<group>"; };
 		FFF605C72A65809B00A1EEC6 /* BrowseScrapCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseScrapCollectionHeaderView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -519,6 +521,7 @@
 			children = (
 				FF6E2D5E2A96636300EA313A /* PopularDesignerResponseDTO.swift */,
 				FFEB5CA82B4E60BA00953362 /* ScrapDesignerResponseDTO.swift */,
+				FFEB5CB02B55AD4300953362 /* GetScrapDesignerResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1221,6 +1224,7 @@
 				FF0FA6152A6D9E1F00482841 /* FilterViewController.swift in Sources */,
 				FF6CC02C2A95072200B24C94 /* PublicRouter.swift in Sources */,
 				FFD9DAF92A7A57430085B965 /* SettingButton.swift in Sources */,
+				FFEB5CB12B55AD4300953362 /* GetScrapDesignerResponseDTO.swift in Sources */,
 				FF04135D2A62F28200BE65F1 /* BrowseDiscoverCollectionViewCell.swift in Sources */,
 				FFA94CEF2A4F1ABD009B034F /* UITextField+.swift in Sources */,
 				FFA707192A59A390003DF6A0 /* Adjusted+.swift in Sources */,

--- a/GAM/GAM.xcodeproj/project.pbxproj
+++ b/GAM/GAM.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		FFEB5CA72B4E5F4F00953362 /* ScrapDesignerRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CA62B4E5F4F00953362 /* ScrapDesignerRequestDTO.swift */; };
 		FFEB5CA92B4E60BA00953362 /* ScrapDesignerResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CA82B4E60BA00953362 /* ScrapDesignerResponseDTO.swift */; };
 		FFEB5CB12B55AD4300953362 /* GetScrapDesignerResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CB02B55AD4300953362 /* GetScrapDesignerResponseDTO.swift */; };
+		FFEB5CB32B562F8300953362 /* GetBrowseDesignerResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB5CB22B562F8300953362 /* GetBrowseDesignerResponseDTO.swift */; };
 		FFF605C22A657CC400A1EEC6 /* BrowseDesignerEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF605C12A657CC400A1EEC6 /* BrowseDesignerEntity.swift */; };
 		FFF605C82A65809B00A1EEC6 /* BrowseScrapCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF605C72A65809B00A1EEC6 /* BrowseScrapCollectionHeaderView.swift */; };
 /* End PBXBuildFile section */
@@ -353,6 +354,7 @@
 		FFEB5CA62B4E5F4F00953362 /* ScrapDesignerRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapDesignerRequestDTO.swift; sourceTree = "<group>"; };
 		FFEB5CA82B4E60BA00953362 /* ScrapDesignerResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapDesignerResponseDTO.swift; sourceTree = "<group>"; };
 		FFEB5CB02B55AD4300953362 /* GetScrapDesignerResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetScrapDesignerResponseDTO.swift; sourceTree = "<group>"; };
+		FFEB5CB22B562F8300953362 /* GetBrowseDesignerResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBrowseDesignerResponseDTO.swift; sourceTree = "<group>"; };
 		FFF605C12A657CC400A1EEC6 /* BrowseDesignerEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseDesignerEntity.swift; sourceTree = "<group>"; };
 		FFF605C72A65809B00A1EEC6 /* BrowseScrapCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseScrapCollectionHeaderView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -522,6 +524,7 @@
 				FF6E2D5E2A96636300EA313A /* PopularDesignerResponseDTO.swift */,
 				FFEB5CA82B4E60BA00953362 /* ScrapDesignerResponseDTO.swift */,
 				FFEB5CB02B55AD4300953362 /* GetScrapDesignerResponseDTO.swift */,
+				FFEB5CB22B562F8300953362 /* GetBrowseDesignerResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1249,6 +1252,7 @@
 				FFD9DAF72A79668E0085B965 /* ToastMessageType.swift in Sources */,
 				FFD9DAFB2A7A58C10085B965 /* MyPortfolioViewController.swift in Sources */,
 				FFCDF8662A5ABBEA00C731A3 /* ShareButton.swift in Sources */,
+				FFEB5CB32B562F8300953362 /* GetBrowseDesignerResponseDTO.swift in Sources */,
 				FF6E2D592A9662C300EA313A /* DesignerRouter.swift in Sources */,
 				FFF605C82A65809B00A1EEC6 /* BrowseScrapCollectionHeaderView.swift in Sources */,
 				FFCDF8592A5A817700C731A3 /* ScrapButton.swift in Sources */,

--- a/GAM/GAM/Network/DTO/Designer/Response/GetBrowseDesignerResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/Designer/Response/GetBrowseDesignerResponseDTO.swift
@@ -50,3 +50,20 @@ struct GetBrowseDesignerResponseDTOElement: Decodable {
 }
 
 typealias GetBrowseDesignerResponseDTO = [GetBrowseDesignerResponseDTOElement]
+
+extension GetBrowseDesignerResponseDTO {
+    func toBrowseDesignerEntity() -> [BrowseDesignerEntity] {
+        return self.map { designerResponse in
+            BrowseDesignerEntity(
+                id: designerResponse.userInfo.userID,
+                thumbnailImageURL: designerResponse.workInfo.photoURL,
+                majorProjectTitle: designerResponse.workInfo.workTitle,
+                name: designerResponse.userInfo.userName,
+                info: designerResponse.userInfo.userDetail,
+                tags: designerResponse.userInfo.userTag,
+                isScrap: designerResponse.userInfo.designerScrap,
+                visibilityCount: designerResponse.userInfo.viewCount
+            )
+        }
+    }
+}

--- a/GAM/GAM/Network/DTO/Designer/Response/GetBrowseDesignerResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/Designer/Response/GetBrowseDesignerResponseDTO.swift
@@ -1,0 +1,52 @@
+//
+//  GetBrowseDesignerResponseDTO.swift
+//  GAM
+//
+//  Created by Jungbin on 1/16/24.
+//
+
+import Foundation
+
+// MARK: - GetBrowseDesignerResponseDTOElement
+
+struct GetBrowseDesignerResponseDTOElement: Decodable {
+    let userInfo: UserInfo
+    let workInfo: WorkInfo
+
+    enum CodingKeys: String, CodingKey {
+        case userInfo = "UserInfo"
+        case workInfo = "WorkInfo"
+    }
+    
+    // MARK: - UserInfo
+    
+    struct UserInfo: Decodable {
+        let userID: Int
+        let userTag: [Int]
+        let userName: String
+        let viewCount: Int
+        let userDetail: String
+        let designerScrap: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case userID = "userId"
+            case userTag, userName, viewCount, userDetail, designerScrap
+        }
+    }
+    
+    // MARK: - WorkInfo
+    
+    struct WorkInfo: Decodable {
+        let workID: Int
+        let workTitle: String
+        let photoURL: String
+
+        enum CodingKeys: String, CodingKey {
+            case workID = "workId"
+            case photoURL = "photoUrl"
+            case workTitle
+        }
+    }
+}
+
+typealias GetBrowseDesignerResponseDTO = [GetBrowseDesignerResponseDTOElement]

--- a/GAM/GAM/Network/DTO/Designer/Response/GetScrapDesignerResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/Designer/Response/GetScrapDesignerResponseDTO.swift
@@ -1,0 +1,36 @@
+//
+//  GetScrapDesignerResponseDTO.swift
+//  GAM
+//
+//  Created by Jungbin on 1/16/24.
+//
+
+import Foundation
+
+struct GetScrapDesignerResponseDTOElement: Codable {
+    let userID: Int
+    let userName: String
+    let userThumbNail: String
+    let userScrapID: Int
+
+    enum CodingKeys: String, CodingKey {
+        case userID = "userId"
+        case userScrapID = "userScrapId"
+        case userName, userThumbNail
+    }
+}
+
+typealias GetScrapDesignerResponseDTO = [GetScrapDesignerResponseDTOElement]
+
+extension GetScrapDesignerResponseDTO {
+    func toBrowseDesignerScrapEntity() -> [BrowseDesignerScrapEntity] {
+        return self.map { designerResponse in
+            BrowseDesignerScrapEntity(
+                id: designerResponse.userID,
+                thumbnailImageURL: designerResponse.userThumbNail,
+                name: designerResponse.userName,
+                isScrap: true
+            )
+        }
+    }
+}

--- a/GAM/GAM/Network/DTO/Designer/Response/GetScrapDesignerResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/Designer/Response/GetScrapDesignerResponseDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct GetScrapDesignerResponseDTOElement: Codable {
+struct GetScrapDesignerResponseDTOElement: Decodable {
     let userID: Int
     let userName: String
     let userThumbNail: String

--- a/GAM/GAM/Network/DTO/Designer/Response/SearchDesignerResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/Designer/Response/SearchDesignerResponseDTO.swift
@@ -13,9 +13,8 @@ struct SearchDesignerResponseDTOElement: Codable {
     let userID, viewCount: Int
 
     enum CodingKeys: String, CodingKey {
-        case thumbNail, title, userName
+        case thumbNail, title, userName, viewCount
         case userID = "userId"
-        case viewCount
     }
 }
 

--- a/GAM/GAM/Network/DTO/Designer/Response/SearchDesignerResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/Designer/Response/SearchDesignerResponseDTO.swift
@@ -1,0 +1,36 @@
+//
+//  SearchDesignerResponseDTO.swift
+//  GAM
+//
+//  Created by Jungbin on 1/16/24.
+//
+
+import Foundation
+
+// MARK: - SearchDesignerResponseDTOElement
+struct SearchDesignerResponseDTOElement: Codable {
+    let thumbNail, title, userName: String
+    let userID, viewCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case thumbNail, title, userName
+        case userID = "userId"
+        case viewCount
+    }
+}
+
+typealias SearchDesignerResponseDTO = [SearchDesignerResponseDTOElement]
+
+extension SearchDesignerResponseDTO {
+    func toPortfolioSearchEntity() -> [PortfolioSearchEntity] {
+        return self.map { designerResponse in
+            PortfolioSearchEntity(
+                id: designerResponse.userID,
+                thumbnailImageURL: designerResponse.thumbNail,
+                title: designerResponse.title,
+                author: designerResponse.userName,
+                visibilityCount: designerResponse.viewCount
+            )
+        }
+    }
+}

--- a/GAM/GAM/Network/DTO/Designer/Response/SearchDesignerResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/Designer/Response/SearchDesignerResponseDTO.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 // MARK: - SearchDesignerResponseDTOElement
-struct SearchDesignerResponseDTOElement: Codable {
+struct SearchDesignerResponseDTOElement: Decodable {
     let thumbNail, title, userName: String
     let userID, viewCount: Int
 

--- a/GAM/GAM/Network/DTO/Magazine/Response/SearchMagazineResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/Magazine/Response/SearchMagazineResponseDTO.swift
@@ -11,6 +11,7 @@ struct SearchMagazineResponseDTOElement: Codable {
     let title: String
     let interviewPerson: String
     let viewCount: Int
+    let magazineUrl: String
 }
 
 typealias SearchMagazineResponseDTO = [SearchMagazineResponseDTOElement]
@@ -26,7 +27,7 @@ extension SearchMagazineResponseDTO {
                     title: self[i].title,
                     author: self[i].interviewPerson,
                     isScrap: false,
-                    url: "",
+                    url: self[i].magazineUrl,
                     visibilityCount: self[i].viewCount
                 )
             )

--- a/GAM/GAM/Network/Routers/DesignerRouter.swift
+++ b/GAM/GAM/Network/Routers/DesignerRouter.swift
@@ -13,6 +13,7 @@ enum DesignerRouter {
     case requestScrapDesigner(data: ScrapDesignerRequestDTO)
     case getBrowseDesigner
     case getScrapDesigner
+    case searchDesigner(data: String)
 }
 
 extension DesignerRouter: TargetType {
@@ -31,12 +32,14 @@ extension DesignerRouter: TargetType {
             return "/user"
         case .getScrapDesigner:
             return "/user/scraps"
+        case .searchDesigner:
+            return "/user/search"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getPopularDesigner, .getBrowseDesigner, .getScrapDesigner:
+        case .getPopularDesigner, .getBrowseDesigner, .getScrapDesigner, .searchDesigner:
             return .get
         case .requestScrapDesigner:
             return .post
@@ -49,6 +52,11 @@ extension DesignerRouter: TargetType {
             return .requestPlain
         case .requestScrapDesigner(let data):
             return .requestJSONEncodable(data)
+        case .searchDesigner(let data):
+            let body: [String : Any] = [
+                "keyword": data
+            ]
+            return .requestParameters(parameters: body, encoding: URLEncoding.queryString)
         }
     }
     

--- a/GAM/GAM/Network/Routers/DesignerRouter.swift
+++ b/GAM/GAM/Network/Routers/DesignerRouter.swift
@@ -11,6 +11,8 @@ import Moya
 enum DesignerRouter {
     case getPopularDesigner
     case requestScrapDesigner(data: ScrapDesignerRequestDTO)
+    case getBrowseDesigner
+    case getScrapDesigner
 }
 
 extension DesignerRouter: TargetType {
@@ -25,12 +27,16 @@ extension DesignerRouter: TargetType {
             return "/user/popular"
         case .requestScrapDesigner:
             return "/user/scrap"
+        case .getBrowseDesigner:
+            return "/user"
+        case .getScrapDesigner:
+            return "/user/scraps"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getPopularDesigner:
+        case .getPopularDesigner, .getBrowseDesigner, .getScrapDesigner:
             return .get
         case .requestScrapDesigner:
             return .post
@@ -39,7 +45,7 @@ extension DesignerRouter: TargetType {
     
     var task: Task {
         switch self {
-        case .getPopularDesigner:
+        case .getPopularDesigner, .getBrowseDesigner, .getScrapDesigner:
             return .requestPlain
         case .requestScrapDesigner(let data):
             return .requestJSONEncodable(data)
@@ -47,12 +53,9 @@ extension DesignerRouter: TargetType {
     }
     
     var headers: [String: String]? {
-        switch self {
-        case .getPopularDesigner, .requestScrapDesigner:
-            return [
-                "Content-Type": "application/json",
-                "Authorization": UserInfo.shared.accessToken
-            ]
-        }
+        return [
+            "Content-Type": "application/json",
+            "Authorization": UserInfo.shared.accessToken
+        ]
     }
 }

--- a/GAM/GAM/Network/Services/DesignerService.swift
+++ b/GAM/GAM/Network/Services/DesignerService.swift
@@ -11,6 +11,8 @@ import Moya
 internal protocol DesignerServiceProtocol {
     func getPopularDesigner(completion: @escaping (NetworkResult<Any>) -> (Void))
     func requestScrapDesigner(data: ScrapDesignerRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void))
+    func getBrowseDesigner(completion: @escaping (NetworkResult<Any>) -> (Void))
+    func getScrapDesigner(completion: @escaping (NetworkResult<Any>) -> (Void))
 }
 
 final class DesignerService: BaseService {
@@ -47,6 +49,38 @@ extension DesignerService: DesignerServiceProtocol {
                 let statusCode = response.statusCode
                 let data = response.data
                 let networkResult = self.judgeStatus(by: statusCode, data, ScrapDesignerResponseDTO.self)
+                completion(networkResult)
+            case .failure(let error):
+                debugPrint(error)
+            }
+        }
+    }
+    
+    // [GET] 발견 - 디자이너
+    
+    func getBrowseDesigner(completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        self.provider.request(.getBrowseDesigner) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, GetBrowseDesignerResponseDTO.self)
+                completion(networkResult)
+            case .failure(let error):
+                debugPrint(error)
+            }
+        }
+    }
+    
+    // [GET] 발견 - 디자이너 스크랩
+    
+    func getScrapDesigner(completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        self.provider.request(.getScrapDesigner) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, GetScrapDesignerResponseDTO.self)
                 completion(networkResult)
             case .failure(let error):
                 debugPrint(error)

--- a/GAM/GAM/Network/Services/DesignerService.swift
+++ b/GAM/GAM/Network/Services/DesignerService.swift
@@ -13,6 +13,7 @@ internal protocol DesignerServiceProtocol {
     func requestScrapDesigner(data: ScrapDesignerRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void))
     func getBrowseDesigner(completion: @escaping (NetworkResult<Any>) -> (Void))
     func getScrapDesigner(completion: @escaping (NetworkResult<Any>) -> (Void))
+    func searchDesigner(data: String, completion: @escaping (NetworkResult<Any>) -> (Void))
 }
 
 final class DesignerService: BaseService {
@@ -81,6 +82,22 @@ extension DesignerService: DesignerServiceProtocol {
                 let statusCode = response.statusCode
                 let data = response.data
                 let networkResult = self.judgeStatus(by: statusCode, data, GetScrapDesignerResponseDTO.self)
+                completion(networkResult)
+            case .failure(let error):
+                debugPrint(error)
+            }
+        }
+    }
+    
+    // [GET] 디자이너 검색
+    
+    func searchDesigner(data: String,completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        self.provider.request(.searchDesigner(data: data)) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, SearchDesignerResponseDTO.self)
                 completion(networkResult)
             case .failure(let error):
                 debugPrint(error)

--- a/GAM/GAM/Network/Services/MagazineService.swift
+++ b/GAM/GAM/Network/Services/MagazineService.swift
@@ -75,7 +75,7 @@ extension MagazineService: MagazineServiceProtocol {
     
     // [PUT] 매거진 스크랩 on/off
     
-    func requestScrapMagazine(data: ScrapMagazineRequestDTO,completion: @escaping (NetworkResult<Any>) -> (Void)) {
+    func requestScrapMagazine(data: ScrapMagazineRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void)) {
         self.provider.request(.requestScrapMagazine(data: data)) { result in
             switch result {
             case .success(let response):
@@ -91,7 +91,7 @@ extension MagazineService: MagazineServiceProtocol {
     
     // [GET] 매거진 검색
     
-    func searchMagazine(data: String,completion: @escaping (NetworkResult<Any>) -> (Void)) {
+    func searchMagazine(data: String, completion: @escaping (NetworkResult<Any>) -> (Void)) {
         self.provider.request(.searchMagazine(data: data)) { result in
             switch result {
             case .success(let response):

--- a/GAM/GAM/Sources/Screens/Browse/BrowseDiscoverViewController.swift
+++ b/GAM/GAM/Sources/Screens/Browse/BrowseDiscoverViewController.swift
@@ -108,9 +108,10 @@ extension BrowseDiscoverViewController: UICollectionViewDataSource {
         cell.scrapButton.removeTarget(nil, action: nil, for: .allTouchEvents)
         cell.scrapButton.setAction { [weak self] in
             if let bool = self?.designers[indexPath.row].isScrap {
-                debugPrint("스크랩 request")
-                self?.designers[indexPath.row].isScrap = !bool
-                cell.scrapButton.isSelected = !bool
+                self?.requestScrapDesigner(data: .init(targetUserId: self?.designers[indexPath.row].id ?? 0, currentScrapStatus: bool)) {
+                    self?.designers[indexPath.row].isScrap = !bool
+                    cell.scrapButton.isSelected = !bool
+                }
             }
         }
         return cell

--- a/GAM/GAM/Sources/Screens/Browse/BrowseDiscoverViewController.swift
+++ b/GAM/GAM/Sources/Screens/Browse/BrowseDiscoverViewController.swift
@@ -34,13 +34,7 @@ final class BrowseDiscoverViewController: BaseViewController {
     
     private var superViewController: BrowseViewController?
     
-    private var designers: [BrowseDesignerEntity] = [
-        BrowseDesignerEntity(id: 0, thumbnailImageURL: "", majorProjectTitle: "L’ESPACE", name: "최가연", info: "삶을 다채롭게 만드는 브랜드 디자이너", tags: [0, 1, 2], isScrap: true, visibilityCount: 1234),
-        BrowseDesignerEntity(id: 1, thumbnailImageURL: "", majorProjectTitle: "L’ESPACE", name: "박경은", info: "삶을 다채롭게 만드는 브랜드 디자이너", tags: [3], isScrap: false, visibilityCount: 2),
-        BrowseDesignerEntity(id: 2, thumbnailImageURL: "", majorProjectTitle: "L’ESPACE", name: "원종화", info: "삶을 다채롭게 만드는 브랜드 디자이너", tags: [5, 7], isScrap: true, visibilityCount: 22),
-        BrowseDesignerEntity(id: 3, thumbnailImageURL: "", majorProjectTitle: "L’ESPACE", name: "정정빈", info: "삶을 다채롭게 만드는 브랜드 디자이너", tags: [2], isScrap: false, visibilityCount: 132),
-        BrowseDesignerEntity(id: 4, thumbnailImageURL: "", majorProjectTitle: "L’ESPACE", name: "최가희", info: "삶을 다채롭게 만드는 브랜드 디자이너", tags: [9, 10], isScrap: true, visibilityCount: 12)
-    ].shuffled()
+    private var designers: [BrowseDesignerEntity] = []
     
     // MARK: Initializer
     
@@ -64,6 +58,12 @@ final class BrowseDiscoverViewController: BaseViewController {
         self.setCollectionView()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.fetchData()
+    }
+    
     // MARK: Methods
     
     private func setCollectionViewLayout() {
@@ -83,6 +83,13 @@ final class BrowseDiscoverViewController: BaseViewController {
         self.collectionView.delegate = self
         
         self.collectionView.register(cell: BrowseDiscoverCollectionViewCell.self)
+    }
+    
+    private func fetchData() {
+        self.getBrowseDesigner { designers in
+            self.designers = designers
+            self.collectionView.reloadData()
+        }
     }
 }
 
@@ -128,6 +135,25 @@ extension BrowseDiscoverViewController: UICollectionViewDelegateFlowLayout {
             y: scrollView.contentInset.top
         )
         targetContentOffset.pointee = offset
+    }
+}
+
+// MARK: - Network
+
+extension BrowseDiscoverViewController {
+    private func getBrowseDesigner(completion: @escaping ([BrowseDesignerEntity]) -> ()) {
+        self.startActivityIndicator()
+        DesignerService.shared.getBrowseDesigner { networkResult in
+            switch networkResult {
+            case .success(let responseData):
+                if let result = responseData as? GetBrowseDesignerResponseDTO {
+                    completion(result.toBrowseDesignerEntity())
+                }
+            default:
+                self.showNetworkErrorAlert()
+            }
+            self.stopActivityIndicator()
+        }
     }
 }
 

--- a/GAM/GAM/Sources/Screens/Browse/BrowseScrapViewController.swift
+++ b/GAM/GAM/Sources/Screens/Browse/BrowseScrapViewController.swift
@@ -65,6 +65,7 @@ final class BrowseScrapViewController: BaseViewController {
         
         self.setLayout()
         self.setCollectionView()
+        self.fetchData()
     }
     
     // MARK: Methods
@@ -77,6 +78,13 @@ final class BrowseScrapViewController: BaseViewController {
         
         self.collectionView.dataSource = self
         self.collectionView.delegate = self
+    }
+    
+    private func fetchData() {
+        self.getScrapDesigner { designers in
+            self.designers = designers
+            self.collectionView.reloadData()
+        }
     }
 }
 
@@ -120,6 +128,25 @@ extension BrowseScrapViewController: UICollectionViewDataSource {
 extension BrowseScrapViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         debugPrint(indexPath, "selected")
+    }
+}
+
+// MARK: - Network
+
+extension BrowseScrapViewController {
+    private func getScrapDesigner(completion: @escaping ([BrowseDesignerScrapEntity]) -> ()) {
+        self.startActivityIndicator()
+        DesignerService.shared.getScrapDesigner { networkResult in
+            switch networkResult {
+            case .success(let responseData):
+                if let result = responseData as? GetScrapDesignerResponseDTO {
+                    completion(result.toBrowseDesignerScrapEntity())
+                }
+            default:
+                self.showNetworkErrorAlert()
+            }
+            self.stopActivityIndicator()
+        }
     }
 }
 

--- a/GAM/GAM/Sources/Screens/Browse/BrowseScrapViewController.swift
+++ b/GAM/GAM/Sources/Screens/Browse/BrowseScrapViewController.swift
@@ -55,6 +55,11 @@ final class BrowseScrapViewController: BaseViewController {
         
         self.setLayout()
         self.setCollectionView()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
         self.fetchData()
     }
     

--- a/GAM/GAM/Sources/Screens/Browse/BrowseScrapViewController.swift
+++ b/GAM/GAM/Sources/Screens/Browse/BrowseScrapViewController.swift
@@ -98,9 +98,10 @@ extension BrowseScrapViewController: UICollectionViewDataSource {
         cell.scrapButton.removeTarget(nil, action: nil, for: .allTouchEvents)
         cell.scrapButton.setAction { [weak self] in
             if let bool = self?.designers[indexPath.row].isScrap {
-                debugPrint("스크랩 request")
-                self?.designers[indexPath.row].isScrap = !bool
-                cell.scrapButton.isSelected = !bool
+                self?.requestScrapDesigner(data: .init(targetUserId: self?.designers[indexPath.row].id ?? 0, currentScrapStatus: bool)) {
+                    self?.designers[indexPath.row].isScrap = !bool
+                    cell.scrapButton.isSelected = !bool
+                }
             }
         }
         return cell

--- a/GAM/GAM/Sources/Screens/Browse/BrowseScrapViewController.swift
+++ b/GAM/GAM/Sources/Screens/Browse/BrowseScrapViewController.swift
@@ -34,17 +34,7 @@ final class BrowseScrapViewController: BaseViewController {
     // MARK: Properties
     
     private var superViewController: BrowseViewController?
-    private var designers: [BrowseDesignerScrapEntity] = [
-        .init(id: 1, thumbnailImageURL: "", name: "최가연", isScrap: true),
-        .init(id: 2, thumbnailImageURL: "", name: "박경은", isScrap: false),
-        .init(id: 3, thumbnailImageURL: "", name: "원종화", isScrap: false),
-        .init(id: 4, thumbnailImageURL: "", name: "정정빈", isScrap: true),
-        .init(id: 5, thumbnailImageURL: "", name: "최가희", isScrap: true),
-        .init(id: 6, thumbnailImageURL: "", name: "이용택", isScrap: false),
-        .init(id: 1, thumbnailImageURL: "", name: "최가연", isScrap: true),
-        .init(id: 2, thumbnailImageURL: "", name: "박경은", isScrap: false),
-        .init(id: 3, thumbnailImageURL: "", name: "원종화", isScrap: false)
-    ].shuffled()
+    private var designers: [BrowseDesignerScrapEntity] = []
     
     // MARK: Initializer
     

--- a/GAM/GAM/Sources/Screens/Home/HomeViewController.swift
+++ b/GAM/GAM/Sources/Screens/Home/HomeViewController.swift
@@ -128,6 +128,7 @@ extension HomeViewController: UICollectionViewDataSource {
         cell.scrapButton.setAction { [weak self] in
             if let bool = self?.designers[indexPath.row].isScrap {
                 self?.requestScrapDesigner(data: .init(targetUserId: self?.designers[indexPath.row].id ?? 0, currentScrapStatus: bool)) {
+                    self?.designers[indexPath.row].isScrap = !bool
                     cell.scrapButton.isSelected = !bool
                 }
             }

--- a/GAM/GAM/Sources/Screens/Search/SearchViewController.swift
+++ b/GAM/GAM/Sources/Screens/Search/SearchViewController.swift
@@ -192,12 +192,12 @@ extension SearchViewController {
         case .magazine:
             self.requestSearchMagazine(data: sender.keyword) { result in
                 self.magazineSearchResultData = result
-                self.searchMagazine(keyword: sender.keyword)
+                self.setRecentSearchMagazine(keyword: sender.keyword)
             }
         case .portfolio:
             self.requestSearchDesigner(data: sender.keyword) { result in
                 self.portfolioSearchResultData = result
-                self.searchPortfolio(keyword: sender.keyword)
+                self.setRecentSearchPortfolio(keyword: sender.keyword)
             }
         }
     }
@@ -232,7 +232,7 @@ extension SearchViewController {
         self.magazineSearchResultDataSource.apply(self.magazineSearchResultSnapshot)
     }
     
-    private func searchMagazine(keyword: String?) {
+    private func setRecentSearchMagazine(keyword: String?) {
         if let keyword = keyword?.trimmingCharacters(in: .whitespaces), keyword.count > 0 {
             self.magazineSearchResultTableView.isHidden = false
             self.setMagazineSearchResultTableView(keyword: keyword)
@@ -286,7 +286,7 @@ extension SearchViewController {
         self.portfolioSearchResultDataSource.apply(self.portfolioSearchResultSnapshot)
     }
     
-    private func searchPortfolio(keyword: String?) {
+    private func setRecentSearchPortfolio(keyword: String?) {
         if let keyword = keyword?.trimmingCharacters(in: .whitespaces), keyword.count > 0 {
             self.portfolioSearchResultTableView.isHidden = false
             self.setPortfolioSearchResultTableView(keyword: keyword)
@@ -333,12 +333,12 @@ extension SearchViewController: UITextFieldDelegate {
         case .magazine: 
             self.requestSearchMagazine(data: textField.text ?? "") { result in
                 self.magazineSearchResultData = result
-                self.searchMagazine(keyword: textField.text)
+                self.setRecentSearchMagazine(keyword: textField.text)
             }
         case .portfolio: 
             self.requestSearchDesigner(data: textField.text ?? "") { result in
                 self.portfolioSearchResultData = result
-                self.searchPortfolio(keyword: textField.text)
+                self.setRecentSearchPortfolio(keyword: textField.text)
             }
         }
         return true


### PR DESCRIPTION
## 작업한 내용
- 둘러보기 - 발견
  - 구현은 했었으나 그냥get + 필터get 서버와의 request body 문제로 보류중입니다. 지금은 네트워크 알럿 뜨는 상태인데 필터까지 서버 구현 완료되고 나면 다시 이슈 파서 진행하겠습니당
- 둘러보기 - 스크랩
- 둘러보기 - 스크랩 on/off
- 둘러보기 - 검색
  - emptyView 나오는 경우까지 코딩을 해 놨으나,, 서버 response 이슈로 아직 테스트가 안 된 상황입니다 (아마 서버쪽에서 구현을 잘 해주신다면 서버 배포 후에는 결과 0개인 경우가 문제없이 잘 나올 겁니다 !!)
  - 검색 결과 빨간색처리는.......... #23 에서 처리하게씁니다.
- 매거진/둘러보기에서 쓰이는 SearchViewController 리팩토링 조금 진행


## 관련 이슈
- Resolved: #55
