### PR TITLE
[CHORE] 닉네임 중복 검사 로직, api 구현

### DIFF
--- a/GAM/GAM.xcodeproj/project.pbxproj
+++ b/GAM/GAM.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		FF6E2D592A9662C300EA313A /* DesignerRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6E2D582A9662C300EA313A /* DesignerRouter.swift */; };
 		FF6E2D5B2A9662FF00EA313A /* DesignerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6E2D5A2A9662FF00EA313A /* DesignerService.swift */; };
 		FF6E2D5F2A96636300EA313A /* PopularDesignerResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6E2D5E2A96636300EA313A /* PopularDesignerResponseDTO.swift */; };
+		FFA2AA572B59076400FCE598 /* CheckUsernameDuplicatedResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA2AA562B59076400FCE598 /* CheckUsernameDuplicatedResponseDTO.swift */; };
 		FFA706E32A4F302F003DF6A0 /* PagingHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA706E22A4F302F003DF6A0 /* PagingHeaderCell.swift */; };
 		FFA706E62A4F318F003DF6A0 /* RxSwiftExt in Frameworks */ = {isa = PBXBuildFile; productRef = FFA706E52A4F318F003DF6A0 /* RxSwiftExt */; };
 		FFA706E82A4F363B003DF6A0 /* PagingTabHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA706E72A4F363B003DF6A0 /* PagingTabHeaderView.swift */; };
@@ -244,6 +245,7 @@
 		FF6E2D582A9662C300EA313A /* DesignerRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignerRouter.swift; sourceTree = "<group>"; };
 		FF6E2D5A2A9662FF00EA313A /* DesignerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignerService.swift; sourceTree = "<group>"; };
 		FF6E2D5E2A96636300EA313A /* PopularDesignerResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularDesignerResponseDTO.swift; sourceTree = "<group>"; };
+		FFA2AA562B59076400FCE598 /* CheckUsernameDuplicatedResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUsernameDuplicatedResponseDTO.swift; sourceTree = "<group>"; };
 		FFA706E22A4F302F003DF6A0 /* PagingHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingHeaderCell.swift; sourceTree = "<group>"; };
 		FFA706E72A4F363B003DF6A0 /* PagingTabHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingTabHeaderView.swift; sourceTree = "<group>"; };
 		FFA706E92A4F39E4003DF6A0 /* MagazineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineViewController.swift; sourceTree = "<group>"; };
@@ -560,6 +562,22 @@
 			path = Response;
 			sourceTree = "<group>";
 		};
+		FFA2AA542B59054A00FCE598 /* User */ = {
+			isa = PBXGroup;
+			children = (
+				FFA2AA552B59054F00FCE598 /* Response */,
+			);
+			path = User;
+			sourceTree = "<group>";
+		};
+		FFA2AA552B59054F00FCE598 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				FFA2AA562B59076400FCE598 /* CheckUsernameDuplicatedResponseDTO.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
 		FFA706DE2A4F2F65003DF6A0 /* Magazine */ = {
 			isa = PBXGroup;
 			children = (
@@ -852,6 +870,7 @@
 		FFA94D1F2A4F1D59009B034F /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				FFA2AA542B59054A00FCE598 /* User */,
 				FF6E2D5C2A96634F00EA313A /* Designer */,
 				FF6E2D542A965F5800EA313A /* Magazine */,
 				FF6CC0382A951FA000B24C94 /* Auth */,
@@ -1323,6 +1342,7 @@
 				FF6CC0292A9506E500B24C94 /* PublicService.swift in Sources */,
 				84C03A092B4D0D7A0058EC79 /* ImageUrlRequestDTO.swift in Sources */,
 				84C03A0D2B4E40500058EC79 /* UploadImageRequestDTO.swift in Sources */,
+				FFA2AA572B59076400FCE598 /* CheckUsernameDuplicatedResponseDTO.swift in Sources */,
 				FFB6AB682B4C395D00695DE4 /* SearchMagazineResponseDTO.swift in Sources */,
 				FFEB5CAB2B4E844D00953362 /* SplashViewController.swift in Sources */,
 				FFD9DAFF2A7A5DA50085B965 /* MyPortfolioTableViewCell.swift in Sources */,

--- a/GAM/GAM/Network/DTO/User/Response/CheckUsernameDuplicatedResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/User/Response/CheckUsernameDuplicatedResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  CheckUsernameDuplicatedResponseDTO.swift
+//  GAM
+//
+//  Created by Jungbin on 1/18/24.
+//
+
+import Foundation
+
+struct CheckUsernameDuplicatedResponseDTO: Decodable {
+    let isDuplicated: Bool
+}

--- a/GAM/GAM/Network/Routers/UserRouter.swift
+++ b/GAM/GAM/Network/Routers/UserRouter.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum UserRouter {
     case requestSignUp(data: SignUpRequestDTO)
+    case checkUsernameDuplicated(data: String)
 }
 
 extension UserRouter: TargetType {
@@ -22,6 +23,8 @@ extension UserRouter: TargetType {
         switch self {
         case .requestSignUp:
             return "/user/onboard"
+        case .checkUsernameDuplicated:
+            return "/user/name/check"
         }
     }
     
@@ -29,6 +32,8 @@ extension UserRouter: TargetType {
         switch self {
         case .requestSignUp:
             return .post
+        case .checkUsernameDuplicated:
+            return .get
         }
     }
     
@@ -41,6 +46,11 @@ extension UserRouter: TargetType {
                 "info": data.info
             ]
             return .requestParameters(parameters: body, encoding: JSONEncoding.prettyPrinted)
+        case .checkUsernameDuplicated(let data):
+            let body: [String: Any] = [
+                "userName": data
+            ]
+            return .requestParameters(parameters: body, encoding: URLEncoding.queryString)
         }
     }
     
@@ -51,8 +61,8 @@ extension UserRouter: TargetType {
                 "Content-Type": "application/json",
                 "Authorization": UserInfo.shared.accessToken
             ]
-//        default:
-//            return ["Content-Type": "application/json"]
+        default:
+            return ["Content-Type": "application/json"]
         }
     }
 }

--- a/GAM/GAM/Network/Services/UserService.swift
+++ b/GAM/GAM/Network/Services/UserService.swift
@@ -10,6 +10,7 @@ import Moya
 
 internal protocol UserServiceProtocol {
     func requestSignUp(data: SignUpRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void))
+    func checkUsernameDuplicated(data: String, completion: @escaping (NetworkResult<Any>) -> (Void))
 }
 
 final class UserService: BaseService {
@@ -30,6 +31,22 @@ extension UserService: UserServiceProtocol {
                 let statusCode = response.statusCode
                 let data = response.data
                 let networkResult = self.judgeStatus(by: statusCode, data, SocialLoginResponseDTO.self)
+                completion(networkResult)
+            case .failure(let error):
+                debugPrint(error)
+            }
+        }
+    }
+    
+    // [GET] 닉네임 중복 검사
+    
+    func checkUsernameDuplicated(data: String, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        self.provider.request(.checkUsernameDuplicated(data: data)) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, CheckUsernameDuplicatedResponseDTO.self)
                 completion(networkResult)
             case .failure(let error):
                 debugPrint(error)

--- a/GAM/GAM/Sources/Components/TextField/SignUpTextField.swift
+++ b/GAM/GAM/Sources/Components/TextField/SignUpTextField.swift
@@ -77,6 +77,7 @@ final class SignUpTextField: UITextField {
             .bind { (owner, _) in
                 owner.text = ""
                 owner.clearButton.isHidden = true
+                owner.sendActions(for: .editingChanged)
             }
             .disposed(by: disposeBag)
     }

--- a/GAM/GAM/Sources/Screens/SignUp/SignUpUsernameViewController.swift
+++ b/GAM/GAM/Sources/Screens/SignUp/SignUpUsernameViewController.swift
@@ -176,6 +176,25 @@ final class SignUpUsernameViewController: BaseViewController {
     }
 }
 
+// MARK: - Network
+
+extension SignUpUsernameViewController {
+    private func checkUsernameDuplicated(username: String, completion: @escaping (Bool) -> ()) {
+        self.startActivityIndicator()
+        UserService.shared.checkUsernameDuplicated(data: username) { networkResult in
+            switch networkResult {
+            case .success(let responseData):
+                if let result = responseData as? CheckUsernameDuplicatedResponseDTO {
+                    completion(result.isDuplicated)
+                }
+            default:
+                self.showNetworkErrorAlert()
+            }
+            self.stopActivityIndicator()
+        }
+    }
+}
+
 // MARK: - UI
 
 extension SignUpUsernameViewController {

--- a/GAM/GAM/Sources/Screens/SignUp/SignUpUsernameViewController.swift
+++ b/GAM/GAM/Sources/Screens/SignUp/SignUpUsernameViewController.swift
@@ -19,6 +19,7 @@ final class SignUpUsernameViewController: BaseViewController {
 """
         static let wrongUsername = "한글, 영문, 숫자만 입력 가능합니다."
         static let done = "입력 완료"
+        static let duplicatedUsername = "이미 사용 중인 닉네임입니다."
     }
     
     // MARK: UIComponents
@@ -110,13 +111,13 @@ final class SignUpUsernameViewController: BaseViewController {
             .distinctUntilChanged()
             .subscribe(onNext: { changedText in
                 self.countLabel.text = "\(changedText.count)/5"
+                self.infoLabel.text = Text.wrongUsername
                 if changedText.count > 0 {
                     let regex = "[가-힣ㄱ-ㅎㅏ-ㅣA-Za-z0-9]{0,5}"
                     if NSPredicate(format: "SELF MATCHES %@", regex).evaluate(with: changedText) && changedText.trimmingCharacters(in: .whitespaces).count >= 1 {
                         self.textField.setUnderlineColor(isCorrect: true)
                         self.infoLabel.isHidden = true
                         self.doneButton.isEnabled = true
-                        SignUpInfo.shared.username = changedText
                     } else {
                         self.textField.setUnderlineColor(isCorrect: false)
                         self.infoLabel.isHidden = false
@@ -149,7 +150,18 @@ final class SignUpUsernameViewController: BaseViewController {
     
     private func setDoneButtonAction() {
         self.doneButton.setAction { [weak self] in
-            self?.navigationController?.pushViewController(SignUpTagViewController(), animated: true)
+            guard let username: String = self?.textField.text
+            else { return }
+            self?.checkUsernameDuplicated(username: username, completion: { isDuplicated in
+                self?.infoLabel.isHidden = !isDuplicated
+                self?.doneButton.isEnabled = !isDuplicated
+                if isDuplicated {
+                    self?.infoLabel.text = Text.duplicatedUsername
+                } else {
+                    SignUpInfo.shared.username = username
+                    self?.navigationController?.pushViewController(SignUpTagViewController(), animated: true)
+                }
+            })
         }
     }
     


### PR DESCRIPTION
## 작업한 내용
- 닉네임 중복 검사 api 연결 구현
- 닉네임 중복 검사 로직 구현 (중복 시 경고라벨, 버튼 비활성화)
- GamTextField에서 clear 버튼 액션 시 textField.text를 변경하는데, 이 경우 .editingChanged 이벤트가 안 들어가던 문제 수정 ..감사합니다


## 📸 스크린샷

https://github.com/Gam-develop/GAM-iOS/assets/43312096/e55a29c8-847f-4003-9f46-60cc98d7bad9





## 관련 이슈
- Resolved: #66
