### PR TITLE
[CHORE] 스크랩 뷰에서 바로 refresh되지 않도록 처리

### DIFF
--- a/GAM/GAM/Sources/Screens/Magazine/MagazineScrapViewController.swift
+++ b/GAM/GAM/Sources/Screens/Magazine/MagazineScrapViewController.swift
@@ -94,7 +94,7 @@ extension MagazineScrapViewController: UITableViewDataSource {
             if let bool = self?.magazines[indexPath.row].isScrap {
                 self?.requestScrapMagazine(data: .init(targetMagazineId: self?.magazines[indexPath.row].id ?? 0, currentScrapStatus: bool)) {
                     cell.scrapButton.isSelected = !bool
-                    self?.fetchData()
+                    self?.magazines[indexPath.row].isScrap = !bool
                 }
             }
         }


### PR DESCRIPTION
## 작업한 내용
- 매거진 스크랩 뷰에서, 스크랩이 off되어도 바로 리스트에서 사라지지 않도록 처리 (기획 요청입니다)
- 디자이너 스크랩 뷰는 이미 해 놨네용..


## 📸 스크린샷

https://github.com/Gam-develop/GAM-iOS/assets/43312096/38028239-c8eb-4412-8551-b2fb55b2dc6b



## 관련 이슈
- Resolved: #75
