### PR TITLE
[FEAT] 둘러보기 - 필터 기능 구현

### DIFF
--- a/GAM/GAM/Network/Routers/UserRouter.swift
+++ b/GAM/GAM/Network/Routers/UserRouter.swift
@@ -13,7 +13,7 @@ enum UserRouter {
     case checkUsernameDuplicated(data: String)
     case getPopularDesigner
     case requestScrapDesigner(data: ScrapDesignerRequestDTO)
-    case getBrowseDesigner
+    case getBrowseDesigner(data: [Int])
     case getScrapDesigner
     case searchDesigner(data: String)
     case getUserProfile(data: GetUserProfileRequestDTO)
@@ -33,7 +33,22 @@ enum UserRouter {
 extension UserRouter: TargetType {
     
     var baseURL: URL {
-        return URL(string: APIConstants.baseURL)!
+        switch self {
+        case .getBrowseDesigner(let data):
+            var path = APIConstants.baseURL + "/user"
+            if data.count == 0 {
+                return URL(string: path)!
+            } else {
+                var queryPath = "?"
+                for i in data {
+                    queryPath += "tags=\(i)&"
+                }
+                queryPath.removeLast()
+                return URL(string: URL(string: path)!.appendingPathComponent(queryPath).absoluteString.removingPercentEncoding ?? path)!
+            }
+        default:
+            return URL(string: APIConstants.baseURL)!
+        }
     }
     
     var path: String {
@@ -47,7 +62,7 @@ extension UserRouter: TargetType {
         case .requestScrapDesigner:
             return "/user/scrap"
         case .getBrowseDesigner:
-            return "/user"
+            return ""
         case .getScrapDesigner:
             return "/user/scraps"
         case .searchDesigner:

--- a/GAM/GAM/Network/Routers/UserRouter.swift
+++ b/GAM/GAM/Network/Routers/UserRouter.swift
@@ -36,16 +36,12 @@ extension UserRouter: TargetType {
         switch self {
         case .getBrowseDesigner(let data):
             var path = APIConstants.baseURL + "/user"
-            if data.count == 0 {
-                return URL(string: path)!
-            } else {
-                var queryPath = "?"
-                for i in data {
-                    queryPath += "tags=\(i)&"
-                }
-                queryPath.removeLast()
-                return URL(string: URL(string: path)!.appendingPathComponent(queryPath).absoluteString.removingPercentEncoding ?? path)!
+            var queryPath = "?"
+            for i in data {
+                queryPath += "tags=\(i)&"
             }
+            queryPath.removeLast()
+            return URL(string: URL(string: path)!.appendingPathComponent(queryPath).absoluteString.removingPercentEncoding ?? path)!
         default:
             return URL(string: APIConstants.baseURL)!
         }

--- a/GAM/GAM/Network/Services/UserService.swift
+++ b/GAM/GAM/Network/Services/UserService.swift
@@ -13,7 +13,7 @@ internal protocol UserServiceProtocol {
     func checkUsernameDuplicated(data: String, completion: @escaping (NetworkResult<Any>) -> (Void))
     func getPopularDesigner(completion: @escaping (NetworkResult<Any>) -> (Void))
     func requestScrapDesigner(data: ScrapDesignerRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void))
-    func getBrowseDesigner(completion: @escaping (NetworkResult<Any>) -> (Void))
+    func getBrowseDesigner(data: [Int], completion: @escaping (NetworkResult<Any>) -> (Void))
     func getScrapDesigner(completion: @escaping (NetworkResult<Any>) -> (Void))
     func searchDesigner(data: String, completion: @escaping (NetworkResult<Any>) -> (Void))
     func getUserProfile(data: GetUserProfileRequestDTO, completion: @escaping (NetworkResult<Any>) -> (Void))
@@ -104,8 +104,8 @@ extension UserService: UserServiceProtocol {
     
     // [GET] 발견 - 디자이너
     
-    func getBrowseDesigner(completion: @escaping (NetworkResult<Any>) -> (Void)) {
-        self.provider.request(.getBrowseDesigner) { result in
+    func getBrowseDesigner(data: [Int], completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        self.provider.request(.getBrowseDesigner(data: data)) { result in
             switch result {
             case .success(let response):
                 let statusCode = response.statusCode

--- a/GAM/GAM/Sources/Screens/Browse/BrowseDiscoverViewController.swift
+++ b/GAM/GAM/Sources/Screens/Browse/BrowseDiscoverViewController.swift
@@ -35,6 +35,7 @@ final class BrowseDiscoverViewController: BaseViewController {
     private var superViewController: BrowseViewController?
     
     private var designers: [BrowseDesignerEntity] = []
+    private var selectedTags: [TagEntity] = []
     
     // MARK: Initializer
     
@@ -61,7 +62,7 @@ final class BrowseDiscoverViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.fetchData()
+        self.fetchData(selectedTags: self.selectedTags)
     }
     
     // MARK: Methods
@@ -85,8 +86,13 @@ final class BrowseDiscoverViewController: BaseViewController {
         self.collectionView.register(cell: BrowseDiscoverCollectionViewCell.self)
     }
     
-    private func fetchData() {
-        self.getBrowseDesigner { designers in
+    func fetchData(selectedTags: [TagEntity]) {
+        self.selectedTags = selectedTags
+        
+        let selectedTagsNumber = selectedTags.map { tag in
+            tag.id
+        }
+        self.getBrowseDesigner(data: selectedTagsNumber) { designers in
             self.designers = designers
             self.collectionView.reloadData()
         }
@@ -142,9 +148,9 @@ extension BrowseDiscoverViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - Network
 
 extension BrowseDiscoverViewController {
-    private func getBrowseDesigner(completion: @escaping ([BrowseDesignerEntity]) -> ()) {
+    private func getBrowseDesigner(data: [Int], completion: @escaping ([BrowseDesignerEntity]) -> ()) {
         self.startActivityIndicator()
-        UserService.shared.getBrowseDesigner { networkResult in
+        UserService.shared.getBrowseDesigner(data: data) { networkResult in
             switch networkResult {
             case .success(let responseData):
                 if let result = responseData as? GetBrowseDesignerResponseDTO {

--- a/GAM/GAM/Sources/Screens/Browse/BrowseViewController.swift
+++ b/GAM/GAM/Sources/Screens/Browse/BrowseViewController.swift
@@ -109,6 +109,9 @@ extension BrowseViewController: SendUpdateDelegate {
         
         self.selectedFilterTagView.setTag(tags: selectedTags)
         self.navigationView.filterButton.isSelected = selectedTags.count != 0
+        if let viewController = self.contentViewControllers[0] as? BrowseDiscoverViewController {
+            viewController.fetchData(selectedTags: selectedTags)
+        }
     }
 }
 


### PR DESCRIPTION
## 작업한 내용
- 기존에 있던 **발견 - 디자이너 get** api는 쿼리 부분이 빠져 있었는데, 쿼리 추가하여도 사용 가능하도록 수정하였습니다.
- 시도 1. requestParameter로 tags 파라미터 넣기 -> 불가능. Moya에서는 query parameter를 딕셔너리 형태로 가져가는데 서버 parameter 스펙상.. key값이 겹침

- 시도 2. path string에 "?tags=1&tags=2" 붙이기 -> 불가능. Moya에서 path String -> URL 형태로 바뀔 때 "?" 문자열이 %3F 라는 .. 놈으로 변환됨

- 시도 3. String 말고 URL 자체를 다루는 baseURL 부분에서 해당 api만 URL을 갈아끼움. 이 과정에서 "?" 문자열을 %3F로 바꾸는 과정을.. 삭제함 (removingPercentEncoding)


## 📸 스크린샷


https://github.com/Gam-develop/GAM-iOS/assets/43312096/d71d8465-3528-42ae-873f-9a1501aed4c3


## 관련 이슈
- Resolved: #86
