### PR TITLE
[FEAT] Firebase Remote Config - 강제 업데이트 로직 구현

### DIFF
--- a/GAM/GAM/Global/Bases/BaseViewController.swift
+++ b/GAM/GAM/Global/Bases/BaseViewController.swift
@@ -224,7 +224,7 @@ GAM 앱에서 보냈습니다.
 
 ——————————————————————————
 User: \(String(describing: UserInfo.shared.userID))
-App Version: \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")
+App Version: \(AppInfo.shared.currentAppVersion())
 Device: \(self.deviceModelName())
 OS Version: \(UIDevice.current.systemVersion)
 """

--- a/GAM/GAM/Global/Extensions/String+.swift
+++ b/GAM/GAM/Global/Extensions/String+.swift
@@ -56,4 +56,8 @@ extension String {
         }
         return false
     }
+    
+    func indexing(_ index: Int) -> String {
+        return String(self[self.index(self.startIndex, offsetBy: index)])
+    }
 }

--- a/GAM/GAM/Global/Singletons/AppInfo.swift
+++ b/GAM/GAM/Global/Singletons/AppInfo.swift
@@ -28,12 +28,12 @@ final class AppInfo {
     func isUpdateNeeded(latest: String) -> Bool {
         let current: String = self.currentAppVersion()
         
-        let latestFirst: Int = Int(latest.indexing(0)) ?? 0
-        let currentFirst: Int = Int(current.indexing(0)) ?? 0
+        let latestMajor: Int = Int(latest.indexing(0)) ?? 0
+        let currentMajor: Int = Int(current.indexing(0)) ?? 0
         
-        let latestSeceond: Int = Int(latest.indexing(2)) ?? 0
-        let currentSecond: Int = Int(current.indexing(2)) ?? 0
+        let latestMinor: Int = Int(latest.indexing(2)) ?? 0
+        let currentMinor: Int = Int(current.indexing(2)) ?? 0
         
-        return latestFirst > currentFirst || latestSeceond > currentSecond
+        return latestMajor > currentMajor || latestMinor > currentMinor
     }
 }

--- a/GAM/GAM/Global/Singletons/AppInfo.swift
+++ b/GAM/GAM/Global/Singletons/AppInfo.swift
@@ -25,4 +25,15 @@ final class AppInfo {
         return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
     }
     
+    func isUpdateNeeded(latest: String) -> Bool {
+        let current: String = self.currentAppVersion()
+        
+        let latestFirst: Int = Int(latest.indexing(0)) ?? 0
+        let currentFirst: Int = Int(current.indexing(0)) ?? 0
+        
+        let latestSeceond: Int = Int(latest.indexing(2)) ?? 0
+        let currentSecond: Int = Int(current.indexing(2)) ?? 0
+        
+        return latestFirst > currentFirst || latestSeceond > currentSecond
+    }
 }

--- a/GAM/GAM/Global/Singletons/AppInfo.swift
+++ b/GAM/GAM/Global/Singletons/AppInfo.swift
@@ -21,4 +21,8 @@ final class AppInfo {
     
     let appID: String = "6477517719"
     
+    func currentAppVersion() -> String {
+        return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+    }
+    
 }

--- a/GAM/GAM/Global/Singletons/AppInfo.swift
+++ b/GAM/GAM/Global/Singletons/AppInfo.swift
@@ -12,8 +12,6 @@ final class AppInfo {
     
     init() { }
     
-    var latestVersion: String = ""
-    
     var url: GamURLEntity = .init(
         intro: "",
         privacyPolicy: "",

--- a/GAM/GAM/Global/Singletons/AppInfo.swift
+++ b/GAM/GAM/Global/Singletons/AppInfo.swift
@@ -18,4 +18,7 @@ final class AppInfo {
         agreement: "",
         makers: ""
     )
+    
+    let appID: String = "6477517719"
+    
 }

--- a/GAM/GAM/Sources/Components/TableViewCell/SettingTableViewCell.swift
+++ b/GAM/GAM/Sources/Components/TableViewCell/SettingTableViewCell.swift
@@ -51,7 +51,7 @@ extension SettingTableViewCell {
         self.menuLabel.text = label
         
         if label == "버전 정보" {
-            self.versionLabel.text = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+            self.versionLabel.text = AppInfo.shared.currentAppVersion()
         }
     }
 }

--- a/GAM/GAM/Sources/Components/View/GamUpdatePopupViewController.swift
+++ b/GAM/GAM/Sources/Components/View/GamUpdatePopupViewController.swift
@@ -78,7 +78,15 @@ final class GamUpdatePopupViewController: BaseViewController {
     // MARK: Methods
     
     private func setUpdateButtonAction() {
-        self.updateButton.setAction { [weak self] in
+        self.updateButton.setAction {
+            if let url = URL(string: "itms-apps://itunes.apple.com/app/\(AppInfo.shared.appID)"),
+               UIApplication.shared.canOpenURL(url) {
+                if #available(iOS 10.0, *) {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                } else {
+                    UIApplication.shared.openURL(url)
+                }
+            }
         }
     }
 }

--- a/GAM/GAM/Sources/Screens/Setting/SettingViewController.swift
+++ b/GAM/GAM/Sources/Screens/Setting/SettingViewController.swift
@@ -123,8 +123,7 @@ extension SettingViewController: UITableViewDelegate {
         case "문의하기":
             self.sendContactMail()
         case "리뷰 남기기":
-            // TODO: - 앱 아이디 필요
-            let url = "itms-apps://itunes.apple.com/app/";
+            let url = "itms-apps://itunes.apple.com/app/\(AppInfo.shared.appID)";
             if let url = URL(string: url), UIApplication.shared.canOpenURL(url) {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             }


### PR DESCRIPTION
## 작업한 내용
- SplashViewController에서, Firebase Remote Config 이용하여 최신 버전 받아오는 기능 추가 (12시간에 한 번씩 업데이트..)
- AppInfo 싱글톤 내부에
  - currentAppVersion() 메서드 추가 및 활용되는 부분 코드.. 변경하였습니다
  - 앱스토어 appID 멤버변수 추가하여 설정 내 '리뷰 남기기' 부분, 업데이트 시 앱스토어로 이동하기 기능에 적용하였습니다 (@wngus4296 )
- 앱 실행 -> 스플래시뷰 -> 강제 업데이트 확인 (1.0.0 중 첫번째, 두 번째 소수점이 바뀌었을 경우)
  - 업데이트 필요: 앱스토어로 이동
  - 업데이트 필요X: 자동로그인 -> 앱 실행
  - remote config error: 자동로그인 -> 앱 실행

## 📸 스크린샷

https://github.com/Gam-develop/GAM-iOS/assets/43312096/142d8613-904b-4404-a216-0e86ee666332



## 관련 이슈
- Resolved: #71
