### PR TITLE
[FIX] 포트폴리오 설명 없이 생성할 경우, placeholder text가 들어감 / 레이아웃 깨짐 해결

### DIFF
--- a/GAM/GAM/Network/Routers/UserRouter.swift
+++ b/GAM/GAM/Network/Routers/UserRouter.swift
@@ -42,6 +42,8 @@ extension UserRouter: TargetType {
             }
             queryPath.removeLast()
             return URL(string: URL(string: path)!.appendingPathComponent(queryPath).absoluteString.removingPercentEncoding ?? path)!
+        case .uploadImage(let data):
+            return URL(string: data.uploadUrl)!
         default:
             return URL(string: APIConstants.baseURL)!
         }

--- a/GAM/GAM/Sources/Components/TableViewCell/PortfolioTableViewCell.swift
+++ b/GAM/GAM/Sources/Components/TableViewCell/PortfolioTableViewCell.swift
@@ -54,22 +54,14 @@ class PortfolioTableViewCell: UITableViewCell {
         self.titleLabel.text = data.title
         self.detailLabel.text = data.detail
         
-        self.underlineView.isHidden = data.detail.count == 0
+        self.underlineView.isHidden = data.detail.isEmpty
         
-//        if data.detail.count == 0 {
-//            self.detailLabel.snp.remakeConstraints { make in
-//                make.top.equalTo(self.repView.snp.bottom)
-//                make.left.right.equalToSuperview().inset(16)
-//                make.height.equalTo(0)
-//                make.bottom.equalToSuperview().inset(24)
-//            }
-//        } else {
-//            self.detailLabel.snp.remakeConstraints { make in
-//                make.top.equalTo(self.underlineView.snp.bottom).offset(8)
-//                make.left.right.equalToSuperview().inset(16)
-//                make.bottom.equalToSuperview().inset(24)
-//            }
-//        }
+        if data.detail.isEmpty {
+            self.detailLabel.snp.updateConstraints { make in
+                make.top.equalTo(self.underlineView.snp.bottom).offset(0)
+                make.bottom.equalToSuperview().inset(0)
+            }
+        }
     }
     
     private func setUI() {

--- a/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
@@ -171,10 +171,10 @@ final class WriteProjectViewController: BaseViewController, UINavigationControll
         self.projectImageEditButton.isHidden = false
     
         self.projectTitleTextField.text = projectData.title
-        self.projectDetailTextView.text = projectData.detail
+        self.projectDetailTextView.text = projectData.detail.isEmpty ? Text.projectDetailPlaceholder : projectData.detail
         self.projectTitleTextField.sendActions(for: .editingChanged)
         
-        if self.projectData.detail == Text.projectDetailPlaceholder {
+        if self.projectData.detail.isEmpty {
             self.projectDetailTextView.textColor = .gamGray3
         } else {
             self.projectDetailTextView.textColor = .gamBlack
@@ -277,7 +277,7 @@ final class WriteProjectViewController: BaseViewController, UINavigationControll
                 id: self.projectData.id,
                 thumbnailImageURL: String(data.fileName.dropFirst(5)),
                 title: self.projectTitleTextField.text ?? "",
-                detail: self.projectDetailTextView.text
+                detail: self.projectDetailTextView.text == Text.projectDetailPlaceholder ? "" : self.projectDetailTextView.text
             )
             completion(data.preSignedUrl)
         }


### PR DESCRIPTION
## 작업한 내용
- 포트폴리오 설명 없이 생성할 경우, placeholder text가 들어가는 오류 해결
- 포트폴리오 설명 없는 경우 셀 레이아웃 깨짐 해결
- 이미지 url 오류 수정 (코드 빠졌었음 ..)

## ETC
- 이미지 업로드 관련해서 뭔가 AWS 오류인 거 같은 ..? 느낌이라 서버분들께 말씀드림! 답변와서 우리 코드 고쳐야되면 고치겠삼

## 📸 스크린샷
![image](https://github.com/Gam-develop/GAM-iOS/assets/58043306/cc1363c6-beb1-45ff-83a5-af11e0615c37)

## 관련 이슈
- Resolved: #91 
- Resolved: #73 
