### PR TITLE
[FIX] textfield 2개 연속 클릭시 화면 너무 올라감

### DIFF
--- a/GAM/GAM/Global/Extensions/UIViewController+.swift
+++ b/GAM/GAM/Global/Extensions/UIViewController+.swift
@@ -11,19 +11,11 @@ import SafariServices
 extension UIViewController {
     
     /**
-     - Description: 화면 터치시 작성 종료
-     */
-    /// 화면 터치시 작성 종료하는 메서드
-    open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        self.view.endEditing(true)
-    }
-    
-    /**
      - Description: 화면 터치시 키보드 내리는 Extension
      */
     @objc
     func dismissKeyboard() {
-        view.endEditing(true)
+        self.view.endEditing(true)
     }
     
     /**

--- a/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
@@ -64,6 +64,7 @@ final class WriteProjectViewController: BaseViewController, UINavigationControll
     private let projectTitleLabel: GamStarLabel = GamStarLabel(text: Text.projectTitle, font: .subhead4Bold)
     private let projectTitleTextField: GamTextField = {
         let textField: GamTextField = GamTextField(type: .none)
+        textField.font = .caption3Medium
         textField.setGamPlaceholder(Text.projectPlaceholder)
         return textField
     }()

--- a/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
@@ -257,9 +257,11 @@ final class WriteProjectViewController: BaseViewController, UINavigationControll
     @objc
     func keyboardWillShow(_ notification: NSNotification) {
         if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
-            let keyboardRectangle = keyboardFrame.cgRectValue
-            self.keyboardHeight = keyboardRectangle.height
-            self.scrollView.setContentOffset(CGPoint(x: 0, y: self.scrollView.contentOffset.y + self.keyboardHeight - 40.adjustedH), animated: true)
+            
+            if !(self.keyboardHeight > 0) {
+                self.scrollView.setContentOffset(CGPoint(x: 0, y: self.projectTitleLabel.frame.minY - 10), animated: true)
+            }
+            self.keyboardHeight = keyboardFrame.cgRectValue.height
         }
     }
     

--- a/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
@@ -267,11 +267,8 @@ final class WriteProjectViewController: BaseViewController, UINavigationControll
     
     @objc
     func keyboardWillHide(_ notification: Notification) {
-        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
-            let keyboardRectangle = keyboardFrame.cgRectValue
-            self.keyboardHeight = keyboardRectangle.height
-            self.scrollView.setContentOffset(CGPoint(x: 0, y: self.scrollView.contentSize.height - self.scrollView.bounds.height), animated: true)
-        }
+        self.keyboardHeight = 0
+        self.scrollView.setContentOffset(.zero, animated: true)
     }
     
     private func setAddProjectData(completion: @escaping (String) -> ()) {

--- a/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
@@ -136,7 +136,6 @@ final class WriteProjectViewController: BaseViewController, UINavigationControll
         super.viewDidLoad()
         
         self.setLayout()
-        self.dismissKeyboard()
         self.setImagePickerController()
         self.setBackButtonAction(self.navigationView.backButton)
         self.setProjectTitleInfoLabel()
@@ -252,7 +251,6 @@ final class WriteProjectViewController: BaseViewController, UINavigationControll
         self.projectDetailTextView.text = Text.projectDetailPlaceholder
         self.projectDetailTextView.textColor = .gamGray3
     }
-    
     
     @objc
     func keyboardWillShow(_ notification: NSNotification) {


### PR DESCRIPTION
## 작업한 내용
- 작성 뷰 내 titleTextField 폰트 수정
- 키보드 너무 올라가는 문제 수정 -> 키보드 내려가 있을 때만! contentOffset 조정하도록 설정 ("제목" label 부터 보이도록 바꿈)
- 키보드 내려갈 때 contentOffset 0으로 수정
- 작성 중 스크롤하면 contentOffset이 풀리는데.. 이건 ............................................................ 모르겠어요

## 📸 스크린샷


https://github.com/Gam-develop/GAM-iOS/assets/43312096/185dfaf8-58e6-46e7-acd5-cd177ee905da


## 관련 이슈
- Resolved: #94
