### PR TITLE
[CHORE] 행간 수정

### DIFF
--- a/GAM/GAM.xcodeproj/project.pbxproj
+++ b/GAM/GAM.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		22E670502BAB0AA7005028BC /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E6704F2BAB0AA7005028BC /* UITextView+.swift */; };
 		840BFFAC2B7B23CF00DF31C3 /* SecessionRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840BFFAB2B7B23CF00DF31C3 /* SecessionRequestDTO.swift */; };
 		845DB2AC2B5034DD007E7ED9 /* WriteProjectViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845DB2AB2B5034DD007E7ED9 /* WriteProjectViewType.swift */; };
 		845DB2AE2B504914007E7ED9 /* UpdateMyPortfolioRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845DB2AD2B504914007E7ED9 /* UpdateMyPortfolioRequestDTO.swift */; };
@@ -230,6 +231,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		22E6704F2BAB0AA7005028BC /* UITextView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+.swift"; sourceTree = "<group>"; };
 		840BFFAB2B7B23CF00DF31C3 /* SecessionRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecessionRequestDTO.swift; sourceTree = "<group>"; };
 		845DB2AB2B5034DD007E7ED9 /* WriteProjectViewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteProjectViewType.swift; sourceTree = "<group>"; };
 		845DB2AD2B504914007E7ED9 /* UpdateMyPortfolioRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateMyPortfolioRequestDTO.swift; sourceTree = "<group>"; };
@@ -820,6 +822,7 @@
 				FFA94D022A4F1B6C009B034F /* UITabBar+.swift */,
 				FFA94D042A4F1B77009B034F /* CALayer+.swift */,
 				FFA707182A59A390003DF6A0 /* Adjusted+.swift */,
+				22E6704F2BAB0AA7005028BC /* UITextView+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1266,6 +1269,7 @@
 				847349932B58D828001DE9E1 /* GetUserProfileResponseDTO.swift in Sources */,
 				FFA94D0A2A4F1BC4009B034F /* ImageCacheManager.swift in Sources */,
 				845DB2AE2B504914007E7ED9 /* UpdateMyPortfolioRequestDTO.swift in Sources */,
+				22E670502BAB0AA7005028BC /* UITextView+.swift in Sources */,
 				FFA706EE2A4F39F3003DF6A0 /* MyViewController.swift in Sources */,
 				FFCDF8682A5AF37D00C731A3 /* SearchButton.swift in Sources */,
 				FFCDF8602A5A98BD00C731A3 /* PopularDesignerEntity.swift in Sources */,

--- a/GAM/GAM/Global/Extensions/UILabel+.swift
+++ b/GAM/GAM/Global/Extensions/UILabel+.swift
@@ -87,9 +87,11 @@ extension UILabel {
         
         switch style {
         case .headline4Bold:
-            paragraphStyle.lineSpacing = style.pointSize * 0.15
+            paragraphStyle.minimumLineHeight = style.pointSize * 1.3
+            paragraphStyle.maximumLineHeight = style.pointSize * 1.3
         default:
-            paragraphStyle.lineSpacing = style.pointSize * 0.24
+            paragraphStyle.minimumLineHeight = style.pointSize * 1.48
+            paragraphStyle.maximumLineHeight = style.pointSize * 1.48
         }
         
         paragraphStyle.lineBreakMode = .byTruncatingTail
@@ -99,6 +101,13 @@ extension UILabel {
             value: paragraphStyle,
             range: NSRange(location: 0, length: attributedString.length)
         )
+        
+        switch style {
+        case .headline4Bold:
+            attributedString.addAttribute(.baselineOffset, value: (style.pointSize * 1.3 - style.lineHeight) / 4, range: NSRange(location: 0, length: attributedString.length))
+        default:
+            attributedString.addAttribute(.baselineOffset, value: (style.pointSize * 1.48 - style.lineHeight) / 4, range: NSRange(location: 0, length: attributedString.length))
+        }
         
         self.attributedText = attributedString
     }

--- a/GAM/GAM/Global/Extensions/UILabel+.swift
+++ b/GAM/GAM/Global/Extensions/UILabel+.swift
@@ -87,12 +87,13 @@ extension UILabel {
         
         switch style {
         case .headline4Bold:
-            paragraphStyle.lineSpacing = style.pointSize * 0.3
+            paragraphStyle.lineSpacing = style.pointSize * 0.15
         default:
-            paragraphStyle.lineSpacing = style.pointSize * 0.48
+            paragraphStyle.lineSpacing = style.pointSize * 0.24
         }
         
         paragraphStyle.lineBreakMode = .byTruncatingTail
+        
         attributedString.addAttribute(
             .paragraphStyle,
             value: paragraphStyle,

--- a/GAM/GAM/Global/Extensions/UITextView+.swift
+++ b/GAM/GAM/Global/Extensions/UITextView+.swift
@@ -34,8 +34,7 @@ extension UITextView {
             paragraphStyle.lineSpacing = style.pointSize * 0.24
         }
         
-        paragraphStyle.lineBreakMode = .byWordWrapping
-        paragraphStyle.lineBreakStrategy = .hangulWordPriority
+        paragraphStyle.lineBreakMode = .byCharWrapping
         
         attributedString.addAttribute(
             .paragraphStyle,

--- a/GAM/GAM/Global/Extensions/UITextView+.swift
+++ b/GAM/GAM/Global/Extensions/UITextView+.swift
@@ -1,0 +1,48 @@
+//
+//  UITextView+.swift
+//  GAM
+//
+//  Created by Juhyeon Byun on 3/20/24.
+//
+
+import UIKit
+
+extension UITextView {
+    
+    func setTextWithStyle(to targetString: String, style: UIFont, color: UIColor) {
+        let text = targetString
+        let attributedString = NSMutableAttributedString(string: text)
+        
+        attributedString.addAttribute(
+            .font,
+            value: style,
+            range: (text as NSString).range(of: targetString)
+        )
+        
+        attributedString.addAttribute(
+            .foregroundColor,
+            value: color,
+            range: (text as NSString).range(of: targetString)
+        )
+        
+        let paragraphStyle = NSMutableParagraphStyle()
+        
+        switch style {
+        case .headline4Bold:
+            paragraphStyle.lineSpacing = style.pointSize * 0.15
+        default:
+            paragraphStyle.lineSpacing = style.pointSize * 0.24
+        }
+        
+        paragraphStyle.lineBreakMode = .byWordWrapping
+        paragraphStyle.lineBreakStrategy = .hangulWordPriority
+        
+        attributedString.addAttribute(
+            .paragraphStyle,
+            value: paragraphStyle,
+            range: NSRange(location: 0, length: attributedString.length)
+        )
+        
+        self.attributedText = attributedString
+    }
+}

--- a/GAM/GAM/Global/Extensions/UITextView+.swift
+++ b/GAM/GAM/Global/Extensions/UITextView+.swift
@@ -29,18 +29,27 @@ extension UITextView {
         
         switch style {
         case .headline4Bold:
-            paragraphStyle.lineSpacing = style.pointSize * 0.15
+            paragraphStyle.minimumLineHeight = style.pointSize * 1.3
+            paragraphStyle.maximumLineHeight = style.pointSize * 1.3
         default:
-            paragraphStyle.lineSpacing = style.pointSize * 0.24
+            paragraphStyle.minimumLineHeight = style.pointSize * 1.48
+            paragraphStyle.maximumLineHeight = style.pointSize * 1.48
         }
         
-        paragraphStyle.lineBreakMode = .byCharWrapping
+        paragraphStyle.lineBreakMode = .byTruncatingTail
         
         attributedString.addAttribute(
             .paragraphStyle,
             value: paragraphStyle,
             range: NSRange(location: 0, length: attributedString.length)
         )
+        
+        switch style {
+        case .headline4Bold:
+            attributedString.addAttribute(.baselineOffset, value: (style.pointSize * 1.3 - style.lineHeight) / 4, range: NSRange(location: 0, length: attributedString.length))
+        default:
+            attributedString.addAttribute(.baselineOffset, value: (style.pointSize * 1.48 - style.lineHeight) / 4, range: NSRange(location: 0, length: attributedString.length))
+        }
         
         self.attributedText = attributedString
     }

--- a/GAM/GAM/Sources/Components/TableViewCell/PortfolioTableViewCell.swift
+++ b/GAM/GAM/Sources/Components/TableViewCell/PortfolioTableViewCell.swift
@@ -112,7 +112,7 @@ class PortfolioTableViewCell: UITableViewCell {
         }
         
         self.detailLabel.snp.makeConstraints { make in
-            make.top.equalTo(self.underlineView.snp.bottom).offset(8 + UIFont.caption3Medium.pointSize * 0.24)
+            make.top.equalTo(self.underlineView.snp.bottom).offset(8 + self.detailLabel.font.pointSize * 0.24)
             make.left.right.equalToSuperview().inset(16)
             make.bottom.equalToSuperview().inset(24)
             make.height.equalTo(0)

--- a/GAM/GAM/Sources/Components/TableViewCell/PortfolioTableViewCell.swift
+++ b/GAM/GAM/Sources/Components/TableViewCell/PortfolioTableViewCell.swift
@@ -112,7 +112,7 @@ class PortfolioTableViewCell: UITableViewCell {
         }
         
         self.detailLabel.snp.makeConstraints { make in
-            make.top.equalTo(self.underlineView.snp.bottom).offset(8 + self.detailLabel.font.pointSize * 0.24)
+            make.top.equalTo(self.underlineView.snp.bottom).offset(8)
             make.left.right.equalToSuperview().inset(16)
             make.bottom.equalToSuperview().inset(24)
             make.height.equalTo(0)

--- a/GAM/GAM/Sources/Components/TableViewCell/PortfolioTableViewCell.swift
+++ b/GAM/GAM/Sources/Components/TableViewCell/PortfolioTableViewCell.swift
@@ -22,7 +22,7 @@ class PortfolioTableViewCell: UITableViewCell {
         return view
     }()
     
-    private let detailLabel: GamSingleLineLabel = GamSingleLineLabel(text: "", font: .caption2Regular)
+    private let detailLabel: GamSingleLineLabel = GamSingleLineLabel(text: "", font: .caption3Medium)
     
     let repView: RepView = RepView()
     
@@ -52,7 +52,7 @@ class PortfolioTableViewCell: UITableViewCell {
     func setData(data: ProjectEntity) {
         self.thumbnailImageView.setImageUrl(data.thumbnailImageURL)
         self.titleLabel.text = data.title
-        self.detailLabel.text = data.detail
+        self.detailLabel.setTextWithStyle(to: data.detail, style: .caption3Medium, color: .gamBlack)
         
         self.underlineView.isHidden = data.detail.isEmpty
         
@@ -60,6 +60,11 @@ class PortfolioTableViewCell: UITableViewCell {
             self.detailLabel.snp.updateConstraints { make in
                 make.top.equalTo(self.underlineView.snp.bottom).offset(0)
                 make.bottom.equalToSuperview().inset(0)
+            }
+        } else {
+            let labelSize = self.detailLabel.sizeThatFits(CGSize(width: self.frame.width, height: CGFloat.greatestFiniteMagnitude))
+            self.detailLabel.snp.updateConstraints { make in
+                make.height.equalTo(labelSize.height)
             }
         }
     }
@@ -77,7 +82,11 @@ class PortfolioTableViewCell: UITableViewCell {
     }
     
     private func setLayout() {
-        self.contentView.addSubviews([thumbnailImageView, repView, titleLabel, underlineView, detailLabel])
+        self.contentView.addSubviews([self.thumbnailImageView,
+                                      self.repView,
+                                      self.titleLabel,
+                                      self.underlineView,
+                                      self.detailLabel])
         
         self.thumbnailImageView.snp.makeConstraints { make in
             make.top.left.right.equalToSuperview()
@@ -103,9 +112,10 @@ class PortfolioTableViewCell: UITableViewCell {
         }
         
         self.detailLabel.snp.makeConstraints { make in
-            make.top.equalTo(self.underlineView.snp.bottom).offset(8)
+            make.top.equalTo(self.underlineView.snp.bottom).offset(8 + UIFont.caption3Medium.pointSize * 0.24)
             make.left.right.equalToSuperview().inset(16)
             make.bottom.equalToSuperview().inset(24)
+            make.height.equalTo(0)
         }
     }
 }

--- a/GAM/GAM/Sources/Components/View/ProfileInfoView.swift
+++ b/GAM/GAM/Sources/Components/View/ProfileInfoView.swift
@@ -13,6 +13,12 @@ final class ProfileInfoView: UIView {
     // MARK: Properties
     private let detailPlaceholder = "경험 위주 자기소개 부탁드립니다."
     
+    enum ViewType {
+        case userProfile
+        case myProfile
+        case editProfile
+    }
+    
     // MARK: UIComponents
     
     let infoTextField: UITextField = {
@@ -30,8 +36,6 @@ final class ProfileInfoView: UIView {
     
     let detailTextView: UITextView = {
         let textView: UITextView = UITextView()
-        textView.font = .caption2Regular
-        textView.textColor = .gamBlack
         textView.textContainerInset = .zero
         textView.contentInset = .zero
         return textView
@@ -52,15 +56,15 @@ final class ProfileInfoView: UIView {
     
     // MARK: Methods
     
-    func setData(info: String, detail: String) {
+    func setData(type: ViewType, info: String, detail: String) {
         self.infoTextField.text = info
         
         if detail.isEmpty {
-            self.detailTextView.text = detailPlaceholder
-            self.detailTextView.textColor = .gamGray3
+            if type != .userProfile {
+                self.detailTextView.setTextWithStyle(to: detailPlaceholder, style: .caption2Regular, color: .gamGray3)
+            }
         } else {
-            self.detailTextView.text = detail
-            self.detailTextView.textColor = .gamBlack
+            self.detailTextView.setTextWithStyle(to: detail, style: .caption2Regular, color: .gamBlack)
         }
     }
     

--- a/GAM/GAM/Sources/Screens/Setting/SecessionViewController.swift
+++ b/GAM/GAM/Sources/Screens/Setting/SecessionViewController.swift
@@ -212,8 +212,7 @@ extension SecessionViewController {
     }
     
     private func setReasonTextViewUI() {
-        self.reasonTextView.text = self.reasonTextVeiwPlaceholder
-        self.reasonTextView.textColor = .gamGray3
+        self.reasonTextView.setTextWithStyle(to: self.reasonTextVeiwPlaceholder, style: .caption2Regular, color: .gamGray3)
     }
 }
 

--- a/GAM/GAM/Sources/Screens/User/EditProfileViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/EditProfileViewController.swift
@@ -147,6 +147,7 @@ final class EditProfileViewController: BaseViewController {
     func setData(profile: UserProfileEntity) {
         self.profile = profile
         self.profileInfoView.setData(
+            type: .editProfile,
             info: profile.info,
             detail: profile.infoDetail
         )
@@ -227,8 +228,7 @@ final class EditProfileViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         if profileInfoView.detailTextView.text.count == 0 {
-            self.profileInfoView.detailTextView.text =  Text.detailPlaceholder
-            self.profileInfoView.detailTextView.textColor = .gamGray3
+            self.profileInfoView.detailTextView.setTextWithStyle(to: Text.detailPlaceholder, style: .caption2Regular, color: .gamGray3)
         }
     }
     
@@ -311,8 +311,7 @@ extension EditProfileViewController: UITextViewDelegate {
     func textViewDidEndEditing(_ textView: UITextView) {
         textView.endEditing(true)
         if self.profileInfoView.detailTextView.text.isEmpty {
-            self.profileInfoView.detailTextView.text =  Text.detailPlaceholder
-            self.profileInfoView.detailTextView.textColor = .gamGray3
+            self.profileInfoView.detailTextView.setTextWithStyle(to: Text.detailPlaceholder, style: .caption2Regular, color: .gamGray3)
         }
     }
 }

--- a/GAM/GAM/Sources/Screens/User/MyProfileViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/MyProfileViewController.swift
@@ -90,6 +90,7 @@ final class MyProfileViewController: BaseViewController {
     func setData(profile: UserProfileEntity) {
         self.profile = profile
         self.profileInfoView.setData(
+            type: .myProfile,
             info: profile.info,
             detail: profile.infoDetail
         )

--- a/GAM/GAM/Sources/Screens/User/UserProfileViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/UserProfileViewController.swift
@@ -76,6 +76,7 @@ final class UserProfileViewController: BaseViewController {
     func setData(profile: UserProfileEntity) {
         self.profile = profile
         self.profileInfoView.setData(
+            type: .userProfile,
             info: profile.info,
             detail: profile.infoDetail
         )

--- a/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
@@ -173,14 +173,9 @@ final class WriteProjectViewController: BaseViewController, UINavigationControll
         self.projectImageEditButton.isHidden = false
     
         self.projectTitleTextField.text = projectData.title
-        self.projectDetailTextView.text = projectData.detail.isEmpty ? Text.projectDetailPlaceholder : projectData.detail
-        self.projectTitleTextField.sendActions(for: .editingChanged)
+        self.projectDetailTextView.setTextWithStyle(to: projectData.detail.isEmpty ? Text.projectDetailPlaceholder : projectData.detail, style: .caption3Medium, color: projectData.detail.isEmpty ? .gamGray3 : .gamBlack)
         
-        if self.projectData.detail.isEmpty {
-            self.projectDetailTextView.textColor = .gamGray3
-        } else {
-            self.projectDetailTextView.textColor = .gamBlack
-        }
+        self.projectTitleTextField.sendActions(for: .editingChanged)
     }
     
     private func setImagePickerController() {
@@ -250,8 +245,7 @@ final class WriteProjectViewController: BaseViewController, UINavigationControll
     
     private func setDetailTextView() {
         self.projectDetailTextView.delegate = self
-        self.projectDetailTextView.text = Text.projectDetailPlaceholder
-        self.projectDetailTextView.textColor = .gamGray3
+        self.projectDetailTextView.setTextWithStyle(to: Text.projectDetailPlaceholder, style: .caption3Medium, color: .gamGray3)
     }
     
     @objc
@@ -336,8 +330,7 @@ extension WriteProjectViewController: UITextViewDelegate {
     func textViewDidEndEditing(_ textView: UITextView) {
         textView.endEditing(true)
         if self.projectDetailTextView.text.isEmpty {
-            self.projectDetailTextView.text =  Text.projectDetailPlaceholder
-            self.projectDetailTextView.textColor = .gamGray3
+            self.projectDetailTextView.setTextWithStyle(to: Text.projectDetailPlaceholder, style: .caption3Medium, color: .gamGray3)
         }
     }
 }


### PR DESCRIPTION
## 작업한 내용
- TextView 행간 수정하였습니다.
- 글자수가 늘어남으로써 label row에 따라 사이즈가 달라졌습니다! height이 제대로 적용안되는 이슈가 있어서 아래와 같이 text 변경될 때 해당 레이블 높이값 계산해서 updateConstraints 해주었습니다! [@ref](https://doorganizedcoding.tistory.com/entry/UILabel-size%EB%A5%BC-Text-size%EC%97%90-%EB%A7%9E%EC%B6%94%EB%8A%94-%EB%B0%A9%EB%B2%95%ED%98%B9%EC%9D%80-%EA%B7%B8-%EB%B0%98%EB%8C%80)
```swift
let labelSize = self.detailLabel.sizeThatFits(CGSize(width: self.frame.width, height: CGFloat.greatestFiniteMagnitude))
self.detailLabel.snp.updateConstraints { make in
    make.height.equalTo(labelSize.height)
}
```

> help
- spacing이 기존에 폰트 사이즈의 0.3 / 0.48로 정해져있는데 이렇게 하면 피그마랑 다르게 너무 넓더라구요 그래서 0.15 / 0.24로 지정해줬는데 피그마랑 거의 동일합니다.. 왜그런지 잘 모르겠어요

| 수정 전 | 수정 후 | 피그마 |
|-|-|-|
| <img width="295" alt="image" src="https://github.com/Gam-develop/GAM-iOS/assets/58043306/d8b4adbc-abbe-4d2d-8e4d-6a7443998d77"> | <img width="289" alt="image" src="https://github.com/Gam-develop/GAM-iOS/assets/58043306/79c4c502-3302-4de0-a0d4-c2b323673c5d">  | <img width="451" alt="image" src="https://github.com/Gam-develop/GAM-iOS/assets/58043306/46752943-382a-41f2-a751-ed41457f381a"> |

## 📸 스크린샷
<img width="300" alt="스크린샷 2024-03-20 22 58 39" src="https://github.com/Gam-develop/GAM-iOS/assets/58043306/e8825f00-f248-4e16-bcd6-9b38561af9a0">


## 관련 이슈
- Resolved: #116 
