### PR TITLE
[FIX] 마이페이지 이미지 필요없는 여백 삭제

### DIFF
--- a/GAM/GAM/Global/Extensions/UIImageView+.swift
+++ b/GAM/GAM/Global/Extensions/UIImageView+.swift
@@ -53,7 +53,6 @@ extension UIImageView {
     func resizeWithWidth(width: CGFloat) -> UIImage? {
         if let currentImage = self.image {
             let imageView = UIImageView(frame: CGRect(origin: .zero, size: CGSize(width: width, height: CGFloat(ceil(width/currentImage.size.width * currentImage.size.height)))))
-            imageView.contentMode = .scaleAspectFit
             imageView.image = currentImage
             UIGraphicsBeginImageContextWithOptions(imageView.bounds.size, false, currentImage.scale)
             guard let context = UIGraphicsGetCurrentContext() else { return nil }

--- a/GAM/GAM/Sources/Components/TableViewCell/PortfolioTableViewCell.swift
+++ b/GAM/GAM/Sources/Components/TableViewCell/PortfolioTableViewCell.swift
@@ -78,7 +78,6 @@ class PortfolioTableViewCell: UITableViewCell {
         self.detailLabel.numberOfLines = 0
         self.detailLabel.lineBreakMode = .byCharWrapping
         self.thumbnailImageView.backgroundColor = .gamWhite
-        self.thumbnailImageView.contentMode = .scaleAspectFit
     }
     
     private func setLayout() {

--- a/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/WriteProjectViewController.swift
@@ -46,7 +46,6 @@ final class WriteProjectViewController: BaseViewController, UINavigationControll
         let imageView: UIImageView = UIImageView()
         imageView.backgroundColor = .gamWhite
         imageView.makeRounded(cornerRadius: 10)
-        imageView.contentMode = .scaleAspectFit
         return imageView
     }()
     private let projectImageUploadButton: UIButton = {


### PR DESCRIPTION
## 작업한 내용
- 이미지들 중 scaletofit으로 설정해서 위아래 공백 생기는 오류 수정했습니다!

## 📸 스크린샷
||||
|-|-|-|
| ![스크린샷, 2024-05-09 22 09 44-1](https://github.com/Gam-develop/GAM-iOS/assets/58043306/1849edcc-5235-4335-96bf-07aecedc168c) | ![스크린샷, 2024-05-09 22 09 42](https://github.com/Gam-develop/GAM-iOS/assets/58043306/b9593923-7ef2-417d-81de-3b82d86e8f56) | ![IMG_1293](https://github.com/Gam-develop/GAM-iOS/assets/58043306/e61ca128-7ea9-49b8-8cdb-0c0d0355de62) |


## 관련 이슈
- Resolved: #126 
