### PR TITLE
[CHORE] 마이페이지 infoview 좌측 간격 수정

### DIFF
--- a/GAM/GAM/Sources/Components/View/ProfileInfoView.swift
+++ b/GAM/GAM/Sources/Components/View/ProfileInfoView.swift
@@ -95,7 +95,7 @@ final class ProfileInfoView: UIView {
         
         self.detailTextView.snp.makeConstraints { make in
             make.top.equalTo(self.underlineView.snp.bottom).offset(12)
-            make.horizontalEdges.equalToSuperview().inset(16)
+            make.horizontalEdges.equalToSuperview().inset(11)
             make.bottom.equalToSuperview().inset(24)
         }
     }


### PR DESCRIPTION
## 작업한 내용
- 마이페이지 info view 좌측 간격 align 수정했습니다.
   - textView에 기본 inset이 들어가있는 거 같더라구요.. 그래서 그냥 일단 layout 잡을 때 inset을 5 줄였습니다..
   - 더 좋은 방법은 고민해보고 찾아보겠습니다


## 📸 스크린샷
<img src="https://github.com/Gam-develop/GAM-iOS/assets/58043306/dd137f6c-d996-428e-bbdd-7b220b6873da" width=220 height=500>


## 관련 이슈
- Resolved: #130 
- Resolved: #53 
