### PR TITLE
[CHORE] 둘러보기 검색 조회수 없애기

### DIFF
--- a/GAM/GAM/Sources/Components/TableViewCell/NoScrapMagazineTableViewCell.swift
+++ b/GAM/GAM/Sources/Components/TableViewCell/NoScrapMagazineTableViewCell.swift
@@ -91,7 +91,7 @@ final class NoScrapMagazineTableViewCell: UITableViewCell {
         self.thumbnailImageView.setImageUrl(data.thumbnailImageURL)
         self.titleLabel.setTextWithStyle(to: data.title, style: .caption3Medium, color: .gamBlack)
         self.authorLabel.text = data.author
-        self.visibilityCountLabel.text = "\(data.visibilityCount)"
+        self.visibilityStackView.isHidden = true
         
         self.highlightKeyword(keyword: keyword)
     }


### PR DESCRIPTION
## 작업한 내용
- 둘러보기에서 검색을 했을 때 cell에 viewCount를 없앴습니다

## 📸 스크린샷
| 매거진 검색 | 둘러보기 검색|
|-|-|
| ![IMG_1509](https://github.com/Gam-develop/GAM-iOS/assets/58043306/9f29a74b-80a9-40c3-a5f8-eac083fe9c37) | ![IMG_1508](https://github.com/Gam-develop/GAM-iOS/assets/58043306/2e5c1a76-0050-4298-a487-89a916dbf2c5) |


## 관련 이슈
- Resolved: #136 
