### PR TITLE
[CHORE] 매거진 공유 버튼 hidden

### DIFF
--- a/GAM/GAM/Sources/Screens/Magazine/MagazineDetailViewController.swift
+++ b/GAM/GAM/Sources/Screens/Magazine/MagazineDetailViewController.swift
@@ -18,7 +18,8 @@ final class MagazineDetailViewController: BaseViewController {
     // MARK: UIComponents
     
     private let navigationView: GamNavigationView = {
-        let view: GamNavigationView = GamNavigationView(type: .backTitleShare)
+//        let view: GamNavigationView = GamNavigationView(type: .backTitleShare)
+        let view: GamNavigationView = GamNavigationView(type: .backTitle)
         view.setCenterTitle(Text.title)
         return view
     }()
@@ -49,7 +50,7 @@ final class MagazineDetailViewController: BaseViewController {
         self.setBackButtonAction(self.navigationView.backButton)
         self.setLayout()
         self.setWebView()
-        self.setShareButtonAction()
+//        self.setShareButtonAction()
     }
     
     // MARK: Methods
@@ -62,7 +63,7 @@ final class MagazineDetailViewController: BaseViewController {
         
         guard let url = URL(string: self.url) else { return }
         
-        var request = URLRequest(url: url)
+        let request = URLRequest(url: url)
         
         let script = WKUserScript(
             source: "window.localStorage.setItem('accessToken','\(UserInfo.shared.accessToken)');",


### PR DESCRIPTION
## 작업한 내용
- 매거진 navigation View를 backTitle로 변경했어요
- 기존 코드들은 2차에서는 필요한 코드라서 주석처리 해두었습니다

## 📸 스크린샷
<image src="https://github.com/Gam-develop/GAM-iOS/assets/58043306/b0eaa052-5464-41db-b27c-026e99547181" width=375 height=812>



## 관련 이슈
- Resolved: #141
