### PR TITLE
[FEAT] 닉네임 수정

### DIFF
--- a/GAM/GAM/Network/DTO/User/Request/UpdateMyProfileRequestDTO.swift
+++ b/GAM/GAM/Network/DTO/User/Request/UpdateMyProfileRequestDTO.swift
@@ -12,11 +12,13 @@ struct UpdateMyProfileRequestDTO: Encodable {
     let userDetail: String
     let email: String
     let tags: [Int]
+    let userName: String
     
-    init(userInfo: String, userDetail: String, email: String, tags: [Int]) {
+    init(userInfo: String, userDetail: String, email: String, tags: [Int], userName: String) {
         self.userInfo = userInfo
         self.userDetail = userDetail
         self.email = email
         self.tags = tags
+        self.userName = userName
     }
 }

--- a/GAM/GAM/Network/DTO/User/Response/UpdateProfileResponseDTO.swift
+++ b/GAM/GAM/Network/DTO/User/Response/UpdateProfileResponseDTO.swift
@@ -12,12 +12,13 @@ struct UpdateProfileResponseDTO: Decodable {
     let userDetail: String
     let email: String
     let tags: [Int]
+    let userName: String
 }
 
 extension UpdateProfileResponseDTO {
     func toUserProfileEntity() -> UserProfileEntity {
         return UserProfileEntity(userID: 0,
-                                 name: "",
+                                 name: userName,
                                  isScrap: false,
                                  info: userInfo,
                                  infoDetail: userDetail,

--- a/GAM/GAM/Sources/Entities/UserProfileEntity.swift
+++ b/GAM/GAM/Sources/Entities/UserProfileEntity.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct UserProfileEntity {
     var userID: Int
-    let name: String
+    var name: String
     var isScrap: Bool
     var info: String
     var infoDetail: String

--- a/GAM/GAM/Sources/Screens/User/EditProfileViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/EditProfileViewController.swift
@@ -227,7 +227,9 @@ final class EditProfileViewController: BaseViewController {
         self.nicknameTextField.rx.controlEvent(.allEditingEvents)
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
-                guard let changedText = owner.nicknameTextField.text else { return }
+                guard let changedText = owner.nicknameTextField.text?.replacingOccurrences(of: " ", with: "") else { return }
+                owner.nicknameTextField.text = changedText
+                
                 owner.isSaveButtonEnable[3] = owner.profile.name == changedText
                 owner.nicknameTextField.font = .caption2Regular
                 owner.nicknameTextField.clearButton.isHidden = changedText.isEmpty

--- a/GAM/GAM/Sources/Screens/User/EditProfileViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/EditProfileViewController.swift
@@ -112,7 +112,7 @@ final class EditProfileViewController: BaseViewController {
     private var profileInfoObservation: NSKeyValueObservation?
     private var tagObservation: NSKeyValueObservation?
     private var emailObservation: NSKeyValueObservation?
-    private var isSaveButtonEnable: [Bool] = [false, false, false, false] {
+    private var isSaveButtonEnable: [Bool] = [false, false, false, true] {
         didSet {
             self.navigationView.saveButton.isEnabled = self.isSaveButtonEnable[0]
                 && self.isSaveButtonEnable[1]
@@ -227,9 +227,8 @@ final class EditProfileViewController: BaseViewController {
         self.nicknameTextField.rx.controlEvent(.allEditingEvents)
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
-                owner.isSaveButtonEnable[3] = false
                 guard let changedText = owner.nicknameTextField.text else { return }
-                
+                owner.isSaveButtonEnable[3] = owner.profile.name == changedText
                 owner.nicknameTextField.font = .caption2Regular
                 owner.nicknameTextField.clearButton.isHidden = changedText.isEmpty
                 owner.nicknameCountLabel.isHidden = changedText.isEmpty

--- a/GAM/GAM/Sources/Screens/User/EditProfileViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/EditProfileViewController.swift
@@ -14,6 +14,7 @@ final class EditProfileViewController: BaseViewController {
     
     private enum Text {
         static let title = "프로필"
+        static let nicknameTitle = "닉네임"
         static let infoTitle = "내소개"
         static let tagTitle = "활동 분야"
         static let emailTitle = "이메일"
@@ -22,6 +23,9 @@ final class EditProfileViewController: BaseViewController {
         static let tagInfo = "최소 1개 선택해 주세요."
         static let emailInfo = "올바른 이메일을 입력해 주세요."
         static let detailPlaceholder = "경험 위주 자기소개 부탁드립니다."
+        static let nicknameAvailable = "사용가능한 닉네임입니다."
+        static let nicknameError = "한글, 영문, 숫자만 입력 가능합니다."
+        static let nicknameCheck = "중복확인"
     }
     
     private enum Number {
@@ -39,6 +43,21 @@ final class EditProfileViewController: BaseViewController {
     
     private let scrollView: UIScrollView = UIScrollView()
     private let contentView: UIView = UIView()
+    
+    private let nicknameTitleLabel: GamSingleLineLabel = GamSingleLineLabel(text: Text.nicknameTitle, font: .subhead4Bold)
+    
+    private let nicknameTextField: GamTextField = {
+        let textField: GamTextField = GamTextField(type: .none)
+        return textField
+    }()
+    
+    private let nicknameCheckButton: GamFullButton = {
+        let button: GamFullButton = GamFullButton(type: .system)
+        button.setTitle(Text.nicknameCheck, for: .normal)
+        button.makeRounded(cornerRadius: 8)
+        button.titleLabel?.font = .body2Medium
+        return button
+    }()
     
     private let infoTitleLabel: GamSingleLineLabel = GamSingleLineLabel(text: Text.infoTitle, font: .subhead4Bold)
     
@@ -426,7 +445,7 @@ extension EditProfileViewController {
     private func setLayout() {
         self.view.addSubviews([navigationView, scrollView])
         self.scrollView.addSubview(contentView)
-        self.contentView.addSubviews([infoTitleLabel, profileInfoView, tagTitleLabel, tagCollectionView, emailTitleLabel, emailTextField, profileInfoLabel, tagInfoLabel, emailInfoLabel, profileInfoDetailCountLabel])
+        self.contentView.addSubviews([nicknameTitleLabel, nicknameTextField, nicknameCheckButton, infoTitleLabel, profileInfoView, tagTitleLabel, tagCollectionView, emailTitleLabel, emailTextField, profileInfoLabel, tagInfoLabel, emailInfoLabel, profileInfoDetailCountLabel])
         
         self.navigationView.snp.makeConstraints { make in
             make.top.equalTo(self.view.safeAreaLayoutGuide)
@@ -443,8 +462,28 @@ extension EditProfileViewController {
             make.edges.width.equalToSuperview()
         }
         
-        self.infoTitleLabel.snp.makeConstraints { make in
+        self.nicknameTitleLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(26)
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.height.equalTo(27)
+        }
+        
+        self.nicknameTextField.snp.makeConstraints { make in
+            make.top.equalTo(self.nicknameTitleLabel.snp.bottom).offset(10)
+            make.leading.equalToSuperview().inset(20)
+            make.trailing.equalTo(self.nicknameCheckButton.snp.leading).offset(-8)
+            make.height.equalTo(44)
+        }
+        
+        self.nicknameCheckButton.snp.makeConstraints { make in
+            make.top.equalTo(self.nicknameTextField)
+            make.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(self.nicknameTextField)
+            make.width.equalTo(72)
+        }
+        
+        self.infoTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.nicknameTextField.snp.bottom).offset(38)
             make.horizontalEdges.equalToSuperview().inset(20)
             make.height.equalTo(27)
         }

--- a/GAM/GAM/Sources/Screens/User/MyViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/MyViewController.swift
@@ -52,13 +52,13 @@ final class MyViewController: BaseViewController {
         self.setUpViews()
         self.setLayout()
         self.bindTabHeader()
-        self.updateUserProfile()
         self.setSettingButtonAction()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        self.updateUserProfile()
         self.showTabBar()
         self.tabHeaderView.collectionView.reloadData()
         self.bindTabHeader()


### PR DESCRIPTION
## 작업한 내용
- 닉네임 수정 UI, API 연결 했습니다
  - 원래 닉네임이랑 같거나 isEmpty인 경우 중복확인 버튼 비활성화
  - 원래 닉네임이랑 같거나 중복확인이 된 경우 버튼 활성화

## 📸 스크린샷
https://github.com/Gam-develop/GAM-iOS/assets/58043306/caf06cbf-d844-45ab-aaf2-14b078c5c170


## 관련 이슈
- Resolved: #145 
