### PR TITLE
[CHORE] 닉네임 중복 케이스 info 추가

### DIFF
--- a/GAM/GAM/Sources/Screens/User/EditProfileViewController.swift
+++ b/GAM/GAM/Sources/Screens/User/EditProfileViewController.swift
@@ -24,7 +24,8 @@ final class EditProfileViewController: BaseViewController {
         static let emailInfo = "올바른 이메일을 입력해 주세요."
         static let detailPlaceholder = "경험 위주 자기소개 부탁드립니다."
         static let nicknameAvailable = "사용가능한 닉네임입니다."
-        static let nicknameError = "한글, 영문, 숫자만 입력 가능합니다."
+        static let nicknameTypeError = "한글, 영문, 숫자만 입력 가능합니다."
+        static let nicknameDuplicated = "이미 사용 중인 닉네임입니다."
         static let nicknameBlank = "닉네임을 입력해주세요."
         static let nicknameCheck = "중복확인"
     }
@@ -249,11 +250,11 @@ final class EditProfileViewController: BaseViewController {
                 }
                 
                 if changedText.isEmpty {
-                    owner.nicknameInfoLabel.isHidden = false
-                    owner.nicknameTextField.layer.borderWidth = 1
                     owner.nicknameTextField.layer.borderColor = UIColor.gamRed.cgColor
                     owner.nicknameInfoLabel.text = Text.nicknameBlank
                     owner.nicknameInfoLabel.textColor = .gamRed
+                    owner.nicknameInfoLabel.isHidden = false
+                    owner.nicknameTextField.layer.borderWidth = 1
                 } else {
                     owner.nicknameInfoLabel.isHidden = true
                     owner.nicknameTextField.layer.borderWidth = 0
@@ -278,24 +279,32 @@ final class EditProfileViewController: BaseViewController {
         self.nicknameCheckButton.rx.tap
             .subscribe(with: self) { owner, _ in
                 guard let nickname = owner.nicknameTextField.text else { return }
-                owner.checkUsernameDuplicated(username: nickname) { isDuplicated in
-                    owner.nicknameInfoLabel.isHidden = false
-                    owner.nicknameTextField.layer.borderWidth = 1
-                    
-                    if isDuplicated {
-                        owner.nicknameTextField.layer.borderColor = UIColor.gamRed.cgColor
-                        owner.nicknameInfoLabel.textColor = .gamRed
-                        owner.nicknameInfoLabel.text = Text.nicknameError
-                    } else {
-                        owner.nicknameTextField.font = .caption3Medium
-                        owner.nicknameCheckButton.isEnabled = false
-                        owner.nicknameCheckButton.backgroundColor = .gamGray2
-                        owner.nicknameTextField.layer.borderColor = UIColor.gamBlack.cgColor
-                        owner.nicknameInfoLabel.text = Text.nicknameAvailable
-                        owner.nicknameInfoLabel.textColor = .gamBlack
-                        owner.isSaveButtonEnable[3] = true
+                
+                let regex = "^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]+$"
+                if NSPredicate(format: "SELF MATCHES %@", regex).evaluate(with: nickname) {
+                    owner.checkUsernameDuplicated(username: nickname) { isDuplicated in
+                        if isDuplicated {
+                            owner.nicknameTextField.layer.borderColor = UIColor.gamRed.cgColor
+                            owner.nicknameInfoLabel.textColor = .gamRed
+                            owner.nicknameInfoLabel.text = Text.nicknameDuplicated
+                        } else {
+                            owner.nicknameTextField.font = .caption3Medium
+                            owner.nicknameCheckButton.isEnabled = false
+                            owner.nicknameCheckButton.backgroundColor = .gamGray2
+                            owner.nicknameTextField.layer.borderColor = UIColor.gamBlack.cgColor
+                            owner.nicknameInfoLabel.text = Text.nicknameAvailable
+                            owner.nicknameInfoLabel.textColor = .gamBlack
+                            owner.isSaveButtonEnable[3] = true
+                        }
                     }
+                } else {
+                    owner.nicknameTextField.layer.borderColor = UIColor.gamRed.cgColor
+                    owner.nicknameInfoLabel.textColor = .gamRed
+                    owner.nicknameInfoLabel.text = Text.nicknameTypeError
                 }
+                
+                owner.nicknameInfoLabel.isHidden = false
+                owner.nicknameTextField.layer.borderWidth = 1
             }
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 작업한 내용
- 닉네임 중복 에러케이스 추가했습니다
- 정규식 확인 후 통과하면 서버 통신해서 중복 확인했습니다~!

## 📸 스크린샷
![Simulator Screen Recording - iPhone 15 Pro - 2024-06-12 at 22 55 33](https://github.com/Gam-develop/GAM-iOS/assets/58043306/de36be65-b514-40aa-97ac-795b99be40ba) ![Simulator Screen Recording - iPhone 15 Pro - 2024-06-12 at 22 57 41](https://github.com/Gam-develop/GAM-iOS/assets/58043306/2e081774-88fa-4465-a05e-10f654fdde06)

## 관련 이슈
- Resolved: #157 
